### PR TITLE
No longer pass option argument to db_delete().

### DIFF
--- a/modules/csl/includes/csl.inc
+++ b/modules/csl/includes/csl.inc
@@ -222,7 +222,7 @@ class CSL {
    */
   public static function Delete($style_name) {
     if (self::Exists($style_name)) {
-      db_delete(self::TABLE, 't')
+      db_delete(self::TABLE)
         ->condition('name', $style_name)
         ->execute();
       return TRUE;


### PR DESCRIPTION
Ontime Ticket: #1100
Identified Issues:
 When deleting a style you get the following ERROR: Recoverable fatal error:
 Argument 2 passed to db_delete() must be an array, string given, called in
 /var/www/html/drupal-7.15/sites/all/modules/islandora_scholar/modules/csl/includes/csl.inc
 on line 225 and defined in db_delete() (line 2448 of
 /var/www/html/drupal-7.15/includes/database/database.inc).
