### PR TITLE
OnTime: #1100

### DIFF
--- a/includes/romeo.tab.inc
+++ b/includes/romeo.tab.inc
@@ -29,7 +29,7 @@ class RomeoView {
    *   be found.
    */
   public static function getISSN($object) {
-    $cache_id = "islandora_scholar_issn_cache_{$object->pid}";
+    $cache_id = "islandora_scholar_issn_cache_{$object->id}";
     // Try to get the issn of the object.
     if ($issn = cache_get($cache_id)) {
       return $issn->data;

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -173,5 +173,5 @@ function islandora_scholar_romeo_access($object) {
 
   return variable_get('islandora_scholar_romeo_enable', FALSE) &&
     in_array('ir:citationCModel', $object->models) &&
-    RomeoView::getISSN($object->pid);
+    RomeoView::getISSN($object);
 }


### PR DESCRIPTION
RoMEO:
After enabling RoMEO lookups in the admin panel and then navigating to a
citation I see this debug message:
Debug: Undefined property: IslandoraFedoraObject::$pid in
/var/www/html/drupal-7.15/sites/all/modules/islandora_scholar/islandora_scholar.module
on line 176 triggered via __get in MagicProperty->__get() (line 82 of
/var/www/html/drupal-7.15/sites/all/libraries/tuque/MagicProperty.php).
and this notice:
Notice: Trying to get property of non-object in RomeoView::getISSN() (line 32 of
/var/www/html/drupal-7.15/sites/all/modules/islandora_scholar/includes/romeo.tab.inc).
