### PR TITLE
Fixes warning in converter.php.

### DIFF
--- a/modules/islandora_scholar_importer/modules/endnotexml_importer/endnotexml_importer.inc
+++ b/modules/islandora_scholar_importer/modules/endnotexml_importer/endnotexml_importer.inc
@@ -95,11 +95,13 @@ class EndNoteXMLImportObject extends IslandoraScholarImportObject {
       Bibutils::Convert($enxml_file, 'EndNoteXML', $mods_file, 'MODS');
 
       $this->mods = file_get_contents($mods_file);
+      $mods_doc = DOMDocument::loadXML($this->mods);
+      $mods_doc->documentElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:mods', 'http://www.loc.gov/mods/v3');
+      $this->mods = $mods_doc->saveXML();
 
       file_delete($enxml_file);
       file_delete($mods_file);
     }
-
     return $this->mods;
   }
 }


### PR DESCRIPTION
warning: Invalid argument supplied for foreach() in /home/nbanks/projects/drupal6/site/sites/berkeley.local/modules/islandora_scholar/modules/citeproc/generators/converter.php on line 493.

Get generated when viewing importing objects, this is largely because the SimpleXMLElement library is awful. The child objects of xpath queries forget their registered namespaces, so running xpath on child objects generates errors because it forgot what "mods:" means. converter.php is absolutely horrid and fixing it seems like a huge time sink with lots of potential problems ensuing, so rather than fix it we'll fix the import so that it forcebly adds the "mods:" prefix for imported objects.
