### PR TITLE
Removed what I think is an SVN artifact from three module .info files

### DIFF
--- a/islandora_scholar.info
+++ b/islandora_scholar.info
@@ -10,5 +10,5 @@ files[] = includes/coins.inc
 files[] = includes/romeo.tab.inc
 files[] = tests/hooked_access.test
 package = Islandora
-version = 7.x-$Format:%h$-dev
+version = 7.x-dev
 core = 7.x

--- a/modules/bibutils/bibutils.info
+++ b/modules/bibutils/bibutils.info
@@ -6,6 +6,6 @@ files[] = includes/bibutils.inc
 files[] = tests/endx2xml.test
 files[] = tests/ris2xml.test
 files[] = tests/transform_test_base.inc
-version = 7.x-$Format:%h$-dev
+version = 7.x-dev
 core = 7.x
 php = 5.2

--- a/modules/csl/csl.info
+++ b/modules/csl/csl.info
@@ -2,5 +2,5 @@ name = CSL
 description = Allow for the storage/retrieval/validation of CSL 1.0 styles.
 package = Islandora Tools
 files[] = includes/csl.inc
-version = 7.x-$Format:%h$-dev
+version = 7.x-dev
 core = 7.x


### PR DESCRIPTION
Three Islandora_Scholar .info files have $Format:%h$ in the version field (while the other .info files do not).  I think these should be removed and the version for these modules should just be 7.x-dev(?)
