### PR TITLE
Increase size of iteration, fix output of exported file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,10 @@ before_install:
 script:
   - ant -buildfile sites/all/modules/islandora_scholar/build.xml lint
   - sites/all/modules/islandora_scholar/tests/scripts/line_endings.sh sites/all/modules/islandora_scholar
-  # XXX: Move the 3rd-party citeproc-php stuff out of the way, so it doesn't
+  # XXX: Move the 3rd-party library stuff out of the way, so it doesn't
   # throw warnings from coder.
   - mv $TRAVIS_BUILD_DIR/modules/citeproc/lib/citeproc-php $HOME
+  - mv $TRAVIS_BUILD_DIR/modules/exporter/lib/tcpdf $HOME
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer --no-empty islandora_scholar
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer --no-empty bibutils
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer --no-empty citation_exporter
@@ -46,8 +47,9 @@ script:
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer --no-empty pmid_importer
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer --no-empty citeproc
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer --no-empty csl
-  # XXX: Move the 3rd-party citeproc-php stuff back in, for tests.
+  # XXX: Move the 3rd-party library stuff back in, for tests.
   - mv $HOME/citeproc-php $TRAVIS_BUILD_DIR/modules/citeproc/lib/
+  - mv $HOME/tcpdf $TRAVIS_BUILD_DIR/modules/exporter/lib/
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_scholar
   - phpunit sites/all/modules/islandora_scholar/modules/citeproc/tests/CSL_Dateparser.test
   - drush test-run --uri=http://localhost:8081 "Islandora Scholar"

--- a/modules/exporter/citation_exporter.install
+++ b/modules/exporter/citation_exporter.install
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ * Installation hooks.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function citation_exporter_schema() {
+  $schema = array();
+
+  $schema['citation_exporter_sets'] = array(
+    'description' => 'Sets being exported',
+    'fields' => array(
+      'id' => array(
+        'description' => 'Identifier for a set to export.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'updated' => array(
+        'description' => 'When this set was last touched.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+    ),
+    'primary key' => array('id'),
+  );
+  $schema['citation_exporter_pids'] = array(
+    'description' => 'PIDs belonging to each set.',
+    'fields' => array(
+      'sid' => array(
+        'description' => 'Identifier of the set.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'pid' => array(
+        'description' => 'A PID in the set to export.',
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+      ),
+    ),
+    'indexes' => array(
+      'set_id' => array('sid'),
+    ),
+    'foreign keys' => array(
+      'set_membership' => array(
+        'table' => 'citation_exporter_sets',
+        'columns' => array('sid' => 'id'),
+      ),
+    ),
+  );
+
+  return $schema;
+}
+
+/**
+ * Install tables to use instead of temporary files.
+ */
+function citation_exporter_update_7100() {
+  $schema = array();
+  $schema['citation_exporter_sets'] = array(
+    'description' => 'Sets being exported',
+    'fields' => array(
+      'id' => array(
+        'description' => 'Identifier for a set to export.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'updated' => array(
+        'description' => 'When this set was last touched.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+    ),
+    'primary key' => array('id'),
+  );
+  $schema['citation_exporter_pids'] = array(
+    'description' => 'PIDs belonging to each set.',
+    'fields' => array(
+      'sid' => array(
+        'description' => 'Identifier of the set.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'pid' => array(
+        'description' => 'A PID in the set to export.',
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+      ),
+    ),
+    'indexes' => array(
+      'set_id' => array('sid'),
+    ),
+    'foreign keys' => array(
+      'set_membership' => array(
+        'table' => 'citation_exporter_sets',
+        'columns' => array('sid' => 'id'),
+      ),
+    ),
+  );
+
+  foreach ($schema as $table_name => $structure) {
+    db_create_table($table_name, $structure);
+  }
+}

--- a/modules/exporter/citation_exporter.module
+++ b/modules/exporter/citation_exporter.module
@@ -41,3 +41,17 @@ function citation_exporter_export() {
   module_load_include('inc', 'citation_exporter', 'includes/citation.export');
   CitationExporter::Export();
 }
+
+/**
+ * Implements hook_cron().
+ */
+function citation_exporter_cron() {
+  // Delete sets which have not been touched in a day.
+  $sets = db_select('citation_exporter_sets', 's')
+    ->fields('s', array('id'))
+    ->condition('updated', time() - 86400, '<')
+    ->execute()
+    ->fetchCol();
+  module_load_include('inc', 'citation_exporter', 'includes/db');
+  array_map('citation_exporter_drop_set', $sets);
+}

--- a/modules/exporter/includes/batch.export.pdf.inc
+++ b/modules/exporter/includes/batch.export.pdf.inc
@@ -21,19 +21,26 @@ module_load_include('inc', 'citation_exporter', 'includes/batch.export.rtf');
 function citation_exporter_batch_get_pdf_operations(array $pids, $style) {
   $temp_file_dir = file_directory_temp();
   $temp_text_file = file_create_filename("pdf_export.txt", $temp_file_dir);
-  $temp_pids_file = file_create_filename("pids.txt", $temp_file_dir);
-  citation_exporter_batch_store_pids_in_file($temp_pids_file, $pids);
+  module_load_include('inc', 'citation_exporter', 'includes/db');
+  $set_id = citation_exporter_create_set($pids);
   $total = count($pids);
   $operations = array();
 
   $queries = $_GET;
   unset($queries['q']);
-  $operations[] = array('citation_exporter_batch_append_citations_to_text_file', array(
-                    $temp_pids_file, $total, $temp_text_file, $style));
+  $operations[] = array(
+    'citation_exporter_batch_append_citations_to_text_file',
+    array($set_id, $total, $temp_text_file, $style),
+  );
   $operations[] = array('citation_exporter_batch_convert_text_to_pdf', array($temp_text_file));
-  $operations[] = array('citation_exporter_batch_redirect', array(
-                    url(request_path(), array('query' => $queries)),
-                    array($temp_text_file, $temp_pids_file)));
+  $operations[] = array(
+    'citation_exporter_batch_redirect',
+    array(
+      url(request_path(), array('query' => $queries)),
+      array($temp_text_file),
+      $set_id,
+    ),
+  );
   return $operations;
 }
 
@@ -47,12 +54,9 @@ function citation_exporter_batch_get_pdf_operations(array $pids, $style) {
  */
 function citation_exporter_batch_convert_text_to_pdf($filename, array &$context) {
   module_load_include('inc', 'citation_exporter', 'includes/pdf');
-  $text = '';
-  $file = fopen($filename, 'rb');
-  while (!feof($file)) {
-    $text .= fread($file, 4096);
-  }
-  fclose($file);
+  $text = file_get_contents($filename);
+  // XXX: Strip out tags.
+  $text = filter_xss($text, array('br', 'i', 'b'));
   $temp_file_dir = file_directory_temp();
   $temp_file = file_create_filename("pdf_export.pdf", $temp_file_dir);
   citation_exporter_create_pdf($text, $temp_file);

--- a/modules/exporter/includes/batch.export.ris.inc
+++ b/modules/exporter/includes/batch.export.ris.inc
@@ -44,7 +44,7 @@ function citation_exporter_batch_combine_mods($pids_filename, $total, $mods_file
     $context['sandbox']['progress'] = 0;
     $context['sandbox']['total'] = $total;
   }
-  list($pids, $remaining) = citation_exporter_batch_get_num_pids_from_file($pids_filename, 5);
+  list($pids, $remaining) = citation_exporter_batch_get_num_pids_from_file($pids_filename, 32);
   _citation_exporter_batch_combine_mods($mods_filename, $pids);
   $context['sandbox']['progress'] = $context['sandbox']['total'] - $remaining;
   if ($context['sandbox']['progress'] != $context['sandbox']['total']) {

--- a/modules/exporter/includes/batch.export.ris.inc
+++ b/modules/exporter/includes/batch.export.ris.inc
@@ -15,40 +15,63 @@
  *   The operations required to generate a RIS file from the given citations.
  */
 function citation_exporter_batch_get_ris_operations(array $pids) {
+  module_load_include('inc', 'citation_exporter', 'includes/db');
   $temp_file_dir = file_directory_temp();
   $temp_mods_file = file_create_filename("mods.xml", $temp_file_dir);
-  $temp_pids_file = file_create_filename("pids.txt", $temp_file_dir);
-  citation_exporter_batch_store_pids_in_file($temp_pids_file, $pids);
+  $set_id = citation_exporter_create_set($pids);
   $total = count($pids);
-  $mods = new DOMDocument();
-  $mods->loadXML('<modsCollection xmlns="http://www.loc.gov/mods/v3" />');
-  $mods->save($temp_mods_file);
 
   $queries = $_GET;
   unset($queries['q']);
   $operations = array();
-  $operations[] = array('citation_exporter_batch_combine_mods', array(
-                    $temp_pids_file, $total, $temp_mods_file));
-  $operations[] = array('citation_exporter_batch_convert_mods_to_ris', array($temp_mods_file));
-  $operations[] = array('citation_exporter_batch_redirect', array(
-                    url(request_path(), array('query' => $queries)),
-                    array($temp_mods_file, $temp_pids_file)));
+  $operations[] = array(
+    'citation_exporter_batch_combine_mods',
+    array($set_id, $total, $temp_mods_file),
+  );
+  $operations[] = array(
+    'citation_exporter_batch_convert_mods_to_ris',
+    array($temp_mods_file),
+  );
+  $operations[] = array(
+    'citation_exporter_batch_redirect',
+    array(
+      url(request_path(), array('query' => $queries)),
+      array($temp_mods_file),
+      $set_id,
+    ),
+  );
   return $operations;
 }
 
 /**
  * Combined MODS batch operation.
  */
-function citation_exporter_batch_combine_mods($pids_filename, $total, $mods_filename, array &$context) {
+function citation_exporter_batch_combine_mods($set_id, $total, $mods_filename, array &$context) {
+  module_load_include('inc', 'citation_exporter', 'includes/db');
   if (empty($context['sandbox'])) {
     $context['sandbox']['progress'] = 0;
     $context['sandbox']['total'] = $total;
+    $context['sandbox']['mods_fragment'] = file_create_filename('mods-fragment', 'temporary://');
   }
-  list($pids, $remaining) = citation_exporter_batch_get_num_pids_from_file($pids_filename, 32);
-  _citation_exporter_batch_combine_mods($mods_filename, $pids);
-  $context['sandbox']['progress'] = $context['sandbox']['total'] - $remaining;
-  if ($context['sandbox']['progress'] != $context['sandbox']['total']) {
+
+  $pids = citation_exporter_get_pids($set_id);
+  _citation_exporter_batch_combine_mods($context['sandbox']['mods_fragment'], $pids);
+  $context['sandbox']['progress'] += count($pids);
+
+  if ($context['sandbox']['progress'] < $context['sandbox']['total']) {
     $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'];
+  }
+  else {
+    $mods = fopen($mods_filename, 'wb');
+    $fragment = fopen($context['sandbox']['mods_fragment'], 'rb');
+
+    fwrite($mods, '<?xml version="1.0" encoding="UTF-8"?>');
+    fwrite($mods, '<modsCollection xmlns="http://www.loc.gov/mods/v3">');
+    stream_copy_to_stream($fragment, $mods);
+    fwrite($mods, '</modsCollection>');
+    fclose($mods);
+    fclose($fragment);
+    file_unmanaged_delete($context['sandbox']['mods_fragment']);
   }
 }
 
@@ -56,21 +79,19 @@ function citation_exporter_batch_combine_mods($pids_filename, $total, $mods_file
  * Fetch the MODS datastreams from the given $pids and combined them.
  */
 function _citation_exporter_batch_combine_mods($filename, array $pids) {
-  $mods = new DOMDocument();
-  $mods->load($filename);
+  $fp = fopen($filename, 'ab');
   foreach ($pids as $pid) {
     $object = islandora_object_load($pid);
     if (isset($object) && isset($object['MODS']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS'])) {
       $datastream = trim($object['MODS']->content);
-      if (!empty($mods)) {
+      if (!empty($datastream)) {
         $doc = new DOMDocument();
         $doc->loadXML($datastream);
-        $node = $mods->importNode($doc->documentElement, TRUE);
-        $mods->documentElement->appendChild($node);
+        fwrite($fp, $doc->saveXML($doc->documentElement));
       }
     }
   }
-  $mods->save($filename);
+  fclose($fp);
 }
 
 /**

--- a/modules/exporter/includes/batch.export.rtf.inc
+++ b/modules/exporter/includes/batch.export.rtf.inc
@@ -19,19 +19,29 @@
 function citation_exporter_batch_get_rtf_operations(array $pids, $style) {
   $temp_file_dir = file_directory_temp();
   $temp_text_file = file_create_filename("rtf_export.txt", $temp_file_dir);
-  $temp_pids_file = file_create_filename("pids.txt", $temp_file_dir);
-  citation_exporter_batch_store_pids_in_file($temp_pids_file, $pids);
+  module_load_include('inc', 'citation_exporter', 'includes/db');
+  $set_id = citation_exporter_create_set($pids);
   $total = count($pids);
   $operations = array();
 
   $queries = $_GET;
   unset($queries['q']);
-  $operations[] = array('citation_exporter_batch_append_citations_to_text_file', array(
-                    $temp_pids_file, $total, $temp_text_file, $style));
-  $operations[] = array('citation_exporter_batch_convert_txt_to_rtf', array($temp_text_file));
-  $operations[] = array('citation_exporter_batch_redirect', array(
-                    url(request_path(), array('query' => $queries)),
-                    array($temp_text_file, $temp_pids_file)));
+  $operations[] = array(
+    'citation_exporter_batch_append_citations_to_text_file',
+    array($set_id, $total, $temp_text_file, $style),
+  );
+  $operations[] = array(
+    'citation_exporter_batch_convert_txt_to_rtf',
+    array($temp_text_file),
+  );
+  $operations[] = array(
+    'citation_exporter_batch_redirect',
+    array(
+      url(request_path(), array('query' => $queries)),
+      array($temp_text_file),
+      $set_id,
+    ),
+  );
   return $operations;
 }
 
@@ -47,21 +57,24 @@ function citation_exporter_batch_add_header_to_text_file($file_name, $header, ar
 /**
  * Append citations to the given textfile.
  *
- * @param string $pids_filename
- *   File containing PID.
+ * @param string $set_id
+ *   Set being built.
  * @param string $text_filename
  *   File citations will be appended to.
  * @param string $style
  *   The CSL style to use when rendering the citations.
  */
-function citation_exporter_batch_append_citations_to_text_file($pids_filename, $total, $text_filename, $style, array &$context) {
+function citation_exporter_batch_append_citations_to_text_file($set_id, $total, $text_filename, $style, array &$context) {
   if (empty($context['sandbox'])) {
     $context['sandbox']['progress'] = 0;
     $context['sandbox']['total'] = $total;
   }
-  list($pids, $remaining) = citation_exporter_batch_get_num_pids_from_file($pids_filename, 5);
+  module_load_include('inc', 'citation_exporter', 'includes/db');
+  $pids = citation_exporter_get_pids($set_id);
+  $context['sandbox']['progress'] += count($pids);
   _citation_exporter_batch_append_citations_to_text_file($pids, $text_filename, $style);
-  $context['sandbox']['progress'] = $context['sandbox']['total'] - $remaining;
+  citation_exporter_drop_pids($set_id, $pids);
+
   if ($context['sandbox']['progress'] != $context['sandbox']['total']) {
     $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'];
   }
@@ -113,23 +126,17 @@ function _citation_exporter_batch_append_citations_to_text_file(array $pids, $fi
  */
 function citation_exporter_batch_convert_txt_to_rtf($filename, array &$context) {
   module_load_include('inc', 'citation_exporter', 'includes/rtf');
-  $text = '';
-  $file = fopen($filename, 'rb');
-  while (!feof($file)) {
-    $text .= fread($file, 4096);
-  }
-  fclose($file);
+  $text = file_get_contents($filename);
+  // XXX: Strip out tags.
+  $text = filter_xss($text, array('br', 'i', 'b'));
+
   $rtf = new RTF();
   $rtf->addText($text);
   /* File */
   $temp_file_dir = file_directory_temp();
   $temp_file_name = file_create_filename("export.rtf", $temp_file_dir);
-  $file = fopen($temp_file_name, 'wb');
-  if ($file !== FALSE) {
-    $document = $rtf->getDocument();
-    fwrite($file, $document);
-    fclose($file);
-  }
+  $document = $rtf->getDocument();
+  file_put_contents($temp_file_name, $document);
   /* Batch Values */
   $context['results']['filename'] = $temp_file_name;
   $context['results']['download_filename'] = 'export.rtf';

--- a/modules/exporter/includes/batch.inc
+++ b/modules/exporter/includes/batch.inc
@@ -54,6 +54,9 @@ function citation_exporter_batch_export(array $pids, $style = NULL, $file_format
 
 /**
  * Store the given pids in the given file.
+ *
+ * @deprecated
+ *   Stash/grab stuff from the database.
  */
 function citation_exporter_batch_store_pids_in_file($filename, array $pids) {
   $handle = fopen($filename, 'wb');
@@ -65,6 +68,9 @@ function citation_exporter_batch_store_pids_in_file($filename, array $pids) {
 
 /**
  * Fetch the stored PIDS from the given file.
+ *
+ * @deprecated
+ *   Stash/grab stuff from the database.
  */
 function citation_exporter_batch_get_pids_from_file($filename) {
   $file = fopen($filename, 'rb');
@@ -78,6 +84,9 @@ function citation_exporter_batch_get_pids_from_file($filename) {
 
 /**
  * Get a number of PIDS from the given file.
+ *
+ * @deprecated
+ *   Stash/grab stuff from the database.
  */
 function citation_exporter_batch_get_num_pids_from_file($filename, $num = 1) {
   $remaining = 0;
@@ -102,10 +111,14 @@ function citation_exporter_batch_get_num_pids_from_file($filename, $num = 1) {
  *
  * Also deletes the file list.
  */
-function citation_exporter_batch_redirect($redirect, array $file_to_unlink, array &$context) {
+function citation_exporter_batch_redirect($redirect, array $file_to_unlink, $set_id, array &$context) {
   foreach ($file_to_unlink as $file) {
     drupal_unlink($file);
   }
+
+  module_load_include('inc', 'citation_exporter', 'includes/db');
+  citation_exporter_drop_set($set_id);
+
   $context['results']['redirect'] = $redirect;
 }
 

--- a/modules/exporter/includes/citation.export.inc
+++ b/modules/exporter/includes/citation.export.inc
@@ -69,26 +69,12 @@ class CitationExporter {
       self::ClearExportTable();
       if (file_exists($filepath)) {
         $file_size = filesize($filepath);
-        header("Content-type: $mime_type");
-        header("Content-length: $file_size");
-        header("Content-Disposition: attachment; filename=\"$download_filename\"");
-        header("Cache-control: protected");
-        $curl_handle = curl_init();
-        if ($curl_handle !== FALSE) {
-          $url = file_create_url($filepath);
-          curl_setopt($curl_handle, CURLOPT_SSL_VERIFYPEER, FALSE);
-          curl_setopt($curl_handle, CURLOPT_SSL_VERIFYHOST, FALSE);
-          // Fail on errors.
-          curl_setopt($curl_handle, CURLOPT_FAILONERROR, 1);
-          // Allow redirects.
-          curl_setopt($curl_handle, CURLOPT_FOLLOWLOCATION, 1);
-          curl_setopt($curl_handle, CURLOPT_USERAGENT, "Mozilla/4.0 pp(compatible; MSIE 5.01; Windows NT 5.0)");
-          // Return into a variable.
-          curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 0);
-          curl_setopt($curl_handle, CURLOPT_URL, $url);
-        }
-        curl_exec($curl_handle);
-        curl_close($curl_handle);
+        drupal_add_http_header('Content-type', $mime_type);
+        drupal_add_http_header('Content-length', $file_size);
+        drupal_add_http_header('Content-Disposition', format_string('attachment; filename="!download_filename"', array(
+          '!download_filename' => $download_filename,
+        )));
+        readfile($filepath);
       }
       else {
         drupal_goto($redirect);

--- a/modules/exporter/includes/db.inc
+++ b/modules/exporter/includes/db.inc
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @file
+ * Database interface.
+ */
+
+/**
+ * Stash a set of PIDs in the database.
+ *
+ * @param array $pids
+ *   An array of PIDs to stash.
+ *
+ * @return string
+ *   The ID of the set in the database, from which the PIDs can be
+ *   retrieved.
+ */
+function citation_exporter_create_set(array $pids = array()) {
+  $id = db_insert('citation_exporter_sets')
+    ->fields(array('updated' => time()))
+    ->execute();
+
+  foreach (array_chunk($pids, 1024) as $chunk) {
+    $insert = db_insert('citation_exporter_pids')
+      ->fields(array('sid', 'pid'));
+    foreach ($chunk as $pid) {
+      $insert->values(array(
+        'sid' => $id,
+        'pid' => $pid,
+      ));
+    }
+    $insert->execute();
+  }
+
+  return $id;
+}
+
+/**
+ * Get PIDs from a set.
+ *
+ * @param string $set_id
+ *   The set from which to get PIDs.
+ * @param int $count
+ *   The number of PIDs to get.
+ *
+ * @return array
+ *   An array of PIDs. There may be fewer than $count.
+ */
+function citation_exporter_get_pids($set_id, $count = 32) {
+  db_update('citation_exporter_sets')
+    ->fields(array(
+      'updated' => time(),
+    ))
+    ->condition('id', $set_id)
+    ->execute();
+  return db_select('citation_exporter_pids', 'p')
+    ->fields('p', array('pid'))
+    ->condition('sid', $set_id)
+    ->range(0, $count)
+    ->execute()
+    ->fetchCol();
+}
+
+/**
+ * Drop the given set from the database.
+ *
+ * @param string $set_id
+ *   The ID of the set to delete.
+ */
+function citation_exporter_drop_set($set_id) {
+  db_delete('citation_exporter_pids')
+    ->condition('sid', $set_id)
+    ->execute();
+  db_delete('citation_exporter_sets')
+    ->condition('id', $set_id)
+    ->execute();
+}
+
+/**
+ * Remove PIDs from a set.
+ *
+ * @param string $set_id
+ *   The set from which to remove the PIDs.
+ * @param array $pids
+ *   An array of PIDs to remove from the set.
+ */
+function citation_exporter_drop_pids($set_id, array $pids) {
+  db_update('citation_exporter_sets')
+    ->fields(array(
+      'updated' => time(),
+    ))
+    ->condition('id', $set_id)
+    ->execute();
+  db_delete('citation_exporter_pids')
+    ->condition('sid', $set_id)
+    ->condition('pid', $pids)
+    ->execute();
+}

--- a/modules/exporter/includes/rtf.inc
+++ b/modules/exporter/includes/rtf.inc
@@ -399,7 +399,7 @@ class RTF {
 
     $doc_buffer = preg_replace("/<hr(.*?)>/i", "\\brdrb\\brdrs\\brdrw30\\brsp20 \\pard\\par ", $doc_buffer);
     $doc_buffer = str_replace("<br/>", "\\par ", $doc_buffer);
-    $doc_buffer = str_replace("<br/>", "\\par ", $doc_buffer);
+    $doc_buffer = str_replace("<br />", "\\par ", $doc_buffer);
     $doc_buffer = str_replace("<tab>", "\\tab ", $doc_buffer);
 
     $doc_buffer = $this->nl2par($doc_buffer);


### PR DESCRIPTION
Somewhat possible that we could try to output a file larger than the allowed amount of memory... Might have to close the output buffers, output our content and then `exit()`, similar to when downloading/outputting datastreams?
