### PR TITLE
7.x update bibutils links

### DIFF
--- a/modules/bibutils/README.txt
+++ b/modules/bibutils/README.txt
@@ -24,4 +24,4 @@ INSTALLATION
 Enable the module in the admin/modules page.
 
 Follow the instructions here to install Bibutils.
-Found here http://www.scripps.edu/~cdputnam/software/bibutils/
+Found here http://sourceforge.net/p/bibutils/home/Bibutils/

--- a/modules/bibutils/bibutils.info
+++ b/modules/bibutils/bibutils.info
@@ -1,5 +1,5 @@
 name = Bibutils
-description = Provides a PHP interface to the bibutils tools. Found here http://www.scripps.edu/~cdputnam/software/bibutils/
+description = Provides a PHP interface to the bibutils tools. Found here http://sourceforge.net/p/bibutils/home/Bibutils/
 package = Islandora Solution Packs
 files[] = includes/ris.inc
 files[] = includes/bibutils.inc


### PR DESCRIPTION
bibutils project has moved to: http://sourceforge.net/p/bibutils/home/Bibutils/. So I updated both README.txt and bibutils.info files to reflect the change to save time for new users. 
