### PR TITLE
Make "lift embargo" more usable in the ingest step context.

### DIFF
--- a/modules/islandora_scholar_embargo/includes/embargo.inc
+++ b/modules/islandora_scholar_embargo/includes/embargo.inc
@@ -380,45 +380,45 @@ function islandora_scholar_embargo_set_display_message($pid, $dsid, $end) {
   if (is_null($dsid)) {
     if ($end === 'indefinite') {
       drupal_set_message(t('A object-level embargo has been set on @label (@pid) indefinitely.',
-          array(
-            '@label' => $object->label,
-            '@pid' => $pid,
-          )
+        array(
+          '@label' => $object->label,
+          '@pid' => $pid,
+        )
       ));
     }
     else {
       $date = new dateTime($end);
       $date = $date->format('M d, Y');
       drupal_set_message(t('A object-level embargo has been set on @label (@pid) until @duration.',
-           array(
-             '@label' => $object->label,
-             '@pid' => $pid,
-             '@duration' => $date,
-           )
-       ));
+        array(
+          '@label' => $object->label,
+          '@pid' => $pid,
+          '@duration' => $date,
+        )
+      ));
     }
   }
   else {
     if ($end === 'indefinite') {
       drupal_set_message(t('A @dsid datastream embargo has been set on @label (@pid) indefinitely.',
-          array(
-            '@dsid' => $dsid,
-            '@label' => $object->label,
-            '@pid' => $pid,
-          )
+        array(
+          '@dsid' => $dsid,
+          '@label' => $object->label,
+          '@pid' => $pid,
+        )
       ));
     }
     else {
       $date = new dateTime($end);
       $date = $date->format('M d, Y');
       drupal_set_message(t('A @dsid datastream embargo has been set on @label (@pid) until @duration.',
-           array(
-             '@dsid' => $dsid,
-             '@label' => $object->label,
-             '@pid' => $pid,
-             '@duration' => $date,
-           )
-       ));
+        array(
+          '@dsid' => $dsid,
+          '@label' => $object->label,
+          '@pid' => $pid,
+          '@duration' => $date,
+        )
+      ));
     }
   }
 }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -301,15 +301,19 @@ function islandora_scholar_embargo_users_to_notify(AbstractObject $object) {
  *
  * The item embargoed is identified by both the pid and dsid values.
  *
- * @param string $pid
- *   A string containing a Fedora PID, which is either the item disembargoed,
- *   or the item in which the datastream to be embargoed exists.
+ * @param string $param
+ *   Either a string containing a Fedora PID or an AbstractObject, representing
+ *   either the item disembargoed, or the item in which the datastream to be
+ *   embargoed exists.
  * @param mixed $dsid
  *   Either NULL--meaning the object should be disembargoed--or a string
  *   representing a datastream ID to be disembargoed.
  */
-function islandora_scholar_embargo_lift_embargo($pid, $dsid = NULL) {
-  $item = islandora_object_load($pid);
+function islandora_scholar_embargo_lift_embargo($param, $dsid = NULL) {
+  $item = $param instanceof AbstractObject ?
+    $param :
+    islandora_object_load($param);
+  $pid = $item->id;
   $xacml = new IslandoraXacml($item);
 
   if ($dsid === NULL) {
@@ -336,14 +340,17 @@ function islandora_scholar_embargo_lift_embargo($pid, $dsid = NULL) {
 
   $xacml->writeBackToFedora();
 
-  $expiry = $rels[0]['object']['value'];
-  // Send email notification.
-  $params['pid'] = $pid;
-  $params['item_title'] = $item->label;
-  $params['dsid'] = isset($dsid) ? $dsid : NULL;
-  $params['expiry_date'] = $expiry;
-  $key = 'lifted_embargo';
-  islandora_embargo_user_notify($key, $item, $params);
+  // Only notify if the object exists in the repository.
+  if ($item instanceof FedoraObject) {
+    $expiry = $rels[0]['object']['value'];
+    // Send email notification.
+    $params['pid'] = $pid;
+    $params['item_title'] = $item->label;
+    $params['dsid'] = isset($dsid) ? $dsid : NULL;
+    $params['expiry_date'] = $expiry;
+    $key = 'lifted_embargo';
+    islandora_embargo_user_notify($key, $item, $params);
+  }
 }
 
 /**


### PR DESCRIPTION
Allow lifting of embargo on `AbstractObject` instances and avoid notifying when doing so (to use in the "undo submit" dealio of ingest steps).
