### PR TITLE
Allow islandora_solr_metadata display for citation, thesis objects

### DIFF
--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -170,9 +170,39 @@ function islandora_scholar_islandora_required_objects(IslandoraTuque $connection
 }
 
 /**
+ * Implements hook_theme().
+ */
+function islandora_scholar_theme($existing, $type, $theme, $path) {
+  return array(
+    'islandora_thesis' => array(
+      'file' => 'theme/theme.inc',
+      'template' => 'theme/islandora-thesis',
+      'pattern' => 'islandora_thesis__',
+      'variables' => array('islandora_object' => NULL),
+    ),
+    'islandora_citation' => array(
+      'file' => 'theme/theme.inc',
+      'template' => 'theme/islandora-citation',
+      'pattern' => 'islandora_citation__',
+      'variables' => array('islandora_object' => NULL),
+    ),
+  );
+}
+
+/**
  * Implements hook_CMODEL_PID_islandora_view_object().
  */
 function islandora_scholar_ir_citationCModel_islandora_view_object($object) {
+  if (module_exists('islandora_solr_metadata')) {
+    module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
+    if (
+      function_exists('islandora_solr_metadata_get_associations_by_cmodels') &&
+      count(islandora_solr_metadata_get_associations_by_cmodels(array('ir:citationCModel'))) > 0
+    ) {
+      $output = theme('islandora_citation', array('object' => $object));
+      return array('' => $output);
+    }
+  }
   module_load_include('inc', 'islandora_scholar', 'includes/utilities');
   return islandora_scholar_get_view($object);
 }
@@ -181,6 +211,16 @@ function islandora_scholar_ir_citationCModel_islandora_view_object($object) {
  * Implements hook_CMODEL_PID_islandora_view_object().
  */
 function islandora_scholar_ir_thesisCModel_islandora_view_object($object) {
+  if (module_exists('islandora_solr_metadata')) {
+    module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
+    if (
+      function_exists('islandora_solr_metadata_get_associations_by_cmodels') &&
+      count(islandora_solr_metadata_get_associations_by_cmodels(array('ir:thesisCModel'))) > 0
+    ) {
+      $output = theme('islandora_thesis', array('object' => $object));
+      return array('' => $output);
+    }
+  }
   module_load_include('inc', 'islandora_scholar', 'includes/utilities');
   return islandora_scholar_get_view($object);
 }

--- a/theme/islandora-citation.tpl.php
+++ b/theme/islandora-citation.tpl.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * This is the template file for the object page for citation objects.
+ */
+?>
+<div class="islandora-object-image">
+  <?php if (isset($variables['preview']) && isset($variables['pdf'])): ?>
+    <a href="<?php print $variables['pdf']; ?>">
+      <img src="<?php print $variables['preview']; ?>"/>
+    </a>
+  <?php endif; ?>
+</div>
+
+<?php if (isset($variables['metadata'])): ?>
+  <div class="citation_metadata">
+    <?php print $variables['metadata']; ?>
+  </div>
+<?php endif; ?>

--- a/theme/islandora-thesis.tpl.php
+++ b/theme/islandora-thesis.tpl.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * This is the template file for the object page for thesis objects.
+ */
+?>
+<div class="islandora-object-image">
+  <?php if (isset($variables['preview']) && isset($variables['pdf'])): ?>
+    <a href="<?php print $variables['pdf']; ?>">
+      <img src="<?php print $variables['preview']; ?>"/>
+    </a>
+  <?php endif; ?>
+</div>
+
+<?php if (isset($variables['metadata'])): ?>
+  <div class="thesis_metadata">
+    <?php print $variables['metadata']; ?>
+  </div>
+<?php endif; ?>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Theme hooks.
+ */
+
+/**
+ * Implements hook_preprocess().
+ */
+function islandora_entities_preprocess_islandora_citation(array &$variables) {
+  module_load_include('inc', 'islandora', 'includes/metadata');
+  $object = $variables['object'];
+  $object_pid = $object->id;
+  if ($object['PREVIEW'] && $object['PDF']) {
+    $variables['preview'] = "/islandora/object/$object_pid/datastream/PREVIEW/view";
+    $variables['pdf'] = "/islandora/object/$object_pid/datastream/PDF/view";
+  }
+  $variables['metadata'] = islandora_retrieve_metadata_markup($object, TRUE);
+}
+
+/**
+ * Implements hook_preprocess().
+ */
+function islandora_entities_preprocess_islandora_thesis(array &$variables) {
+  module_load_include('inc', 'islandora', 'includes/metadata');
+  $object = $variables['object'];
+  $object_pid = $object->id;
+  if ($object['PREVIEW'] && $object['PDF']) {
+    $variables['preview'] = "/islandora/object/$object_pid/datastream/PREVIEW/view";
+    $variables['pdf'] = "/islandora/object/$object_pid/datastream/PDF/view";
+  }
+  $variables['metadata'] = islandora_retrieve_metadata_markup($object, TRUE);
+}


### PR DESCRIPTION
Implements islandora_solr_metadata display for citation, thesis objects.

Checks to see if
- _islandora_solr_metadata_ is installed
- A field configuration has been created for the current content model
  and if both are true, renders the display with the user-configured solr metadata fields. Otherwise, it falls back to the old COINS method defined by this module.

There is some copy/paste code here between thesis/citation that could be refactored/expressed into more efficient methods, but I felt it best to keep hooks and templates completely separate for unique content models.
