### PR TITLE
Increase quality of PDF previews by controlling density used to generate...

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -251,7 +251,7 @@ function islandora_scholar_admin_pdf_form($form, &$form_state) {
     '#title' => t('Density used to generate preview'),
     '#description' => t('The imagemagick density value used to generate the preview. Generally, higher numbers are better but require more computation time.'),
     '#element_validate' => array('element_validate_number'),
-    '#default_value' => variable_get('islandora_scholar_preview_density', 600),
+    '#default_value' => variable_get('islandora_scholar_preview_density', 75),
     '#size' => 5,
   );
   return system_settings_form($form);

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -246,6 +246,14 @@ function islandora_scholar_admin_pdf_form($form, &$form_state) {
     '#default_value' => variable_get('islandora_scholar_preview_height', 700),
     '#size' => 5,
   );
+  $form['islandora_scholar_preview_fieldset']['islandora_scholar_preview_density'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Density used to generate preview'),
+    '#description' => t('The imagemagick density value used to generate the preview. Generally, higher numbers are better but require more computation time.'),
+    '#element_validate' => array('element_validate_number'),
+    '#default_value' => variable_get('islandora_scholar_preview_density', 600),
+    '#size' => 5,
+  );
   return system_settings_form($form);
 }
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -251,7 +251,7 @@ function islandora_scholar_admin_pdf_form($form, &$form_state) {
     '#title' => t('Density used to generate preview'),
     '#description' => t('The imagemagick density value used to generate the preview. Generally, higher numbers are better but require more computation time.'),
     '#element_validate' => array('element_validate_number'),
-    '#default_value' => variable_get('islandora_scholar_preview_density', 75),
+    '#default_value' => variable_get('islandora_scholar_preview_density', 72),
     '#size' => 5,
   );
   return system_settings_form($form);

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -269,7 +269,7 @@ function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $heig
   // To make use of ImageMagick 6's parenthetical command grouping we need to
   // make the $source image the first parameter and $dest the last.
   // See http://www.imagemagick.org/Usage/basics/#cmdline
-  $command = escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
+  $command = '-density ' . variable_get('islandora_scholar_preview_density', 600) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -269,7 +269,7 @@ function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $heig
   // To make use of ImageMagick 6's parenthetical command grouping we need to
   // make the $source image the first parameter and $dest the last.
   // See http://www.imagemagick.org/Usage/basics/#cmdline
-  $command = escapeshellarg('-density ' . variable_get('islandora_scholar_preview_density', 75)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
+  $command = escapeshellarg('-density ' . variable_get('islandora_scholar_preview_density', 72)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -269,7 +269,7 @@ function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $heig
   // To make use of ImageMagick 6's parenthetical command grouping we need to
   // make the $source image the first parameter and $dest the last.
   // See http://www.imagemagick.org/Usage/basics/#cmdline
-  $command = escapeshellarg('-density ' . variable_get('islandora_scholar_preview_density', 600)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
+  $command = escapeshellarg('-density ' . variable_get('islandora_scholar_preview_density', 75)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -269,7 +269,7 @@ function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $heig
   // To make use of ImageMagick 6's parenthetical command grouping we need to
   // make the $source image the first parameter and $dest the last.
   // See http://www.imagemagick.org/Usage/basics/#cmdline
-  $command = escapeshellarg('-density ' . variable_get('islandora_scholar_preview_density', 72)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
+  $command = '-density ' . escapeshellarg(variable_get('islandora_scholar_preview_density', 72)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -269,7 +269,7 @@ function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $heig
   // To make use of ImageMagick 6's parenthetical command grouping we need to
   // make the $source image the first parameter and $dest the last.
   // See http://www.imagemagick.org/Usage/basics/#cmdline
-  $command = '-density ' . variable_get('islandora_scholar_preview_density', 600) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
+  $command = escapeshellarg('-density ' . variable_get('islandora_scholar_preview_density', 600)) . ' ' . escapeshellarg($source) . ' ' . implode(' ', $args) . ' ' . escapeshellarg("jpg:$dest");
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {

--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -35,6 +35,7 @@ function islandora_scholar_uninstall() {
     'islandora_scholar_romeo_url',
     'islandora_scholar_romeo_cache_time',
     'islandora_scholar_create_fulltext',
+    'islandora_scholar_preview_density',
   );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
Increase preview quality by allowing user control of density used. Defaulting to 600 significantly improves the text rendering in PDF->JPG.

![screen shot 2014-10-06 at 8 25 22 pm](https://cloud.githubusercontent.com/assets/244894/4535283/c5e63184-4db0-11e4-8e2b-60f4004c0967.png)
![screen shot 2014-10-06 at 8 25 08 pm](https://cloud.githubusercontent.com/assets/244894/4535284/c90ad8c4-4db0-11e4-907a-2dd13e7558c5.png)
