### PR TITLE
To fix the scope of the  variable defined in the lib/tcpdf/lang/*.php ...

### DIFF
--- a/modules/exporter/includes/pdf.inc
+++ b/modules/exporter/includes/pdf.inc
@@ -29,8 +29,11 @@
  *   The location to save the generated PDF.
  */
 function citation_exporter_create_pdf($html_input, $output_filename) {
-  require_once DRUPAL_ROOT . '/' . drupal_get_path('module', 'citation_exporter') . '/lib/tcpdf/config/lang/eng.php';
+  module_load_include('php', 'citation_exporter', '/lib/tcpdf/config/lang/eng');
   module_load_include('php', 'citation_exporter', '/lib/tcpdf/tcpdf');
+  
+  // XXX: pull in language array defined inside of the tcpdf config lang file.
+  global $l;
 
   // Create new PDF document.
   $pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, TRUE, 'UTF-8', FALSE, FALSE);

--- a/modules/exporter/includes/pdf.inc
+++ b/modules/exporter/includes/pdf.inc
@@ -29,13 +29,7 @@
  *   The location to save the generated PDF.
  */
 function citation_exporter_create_pdf($html_input, $output_filename) {
-  module_load_include('php', 'citation_exporter', '/lib/tcpdf/config/lang/eng');
   module_load_include('php', 'citation_exporter', '/lib/tcpdf/tcpdf');
-
-  // @codingStandardsIgnoreStart
-  // XXX: pull in language array defined inside of the tcpdf config lang file.
-  global $l;
-  // @codingStandardsIgnoreEnd
 
   // Create new PDF document.
   $pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, TRUE, 'UTF-8', FALSE, FALSE);
@@ -53,9 +47,6 @@ function citation_exporter_create_pdf($html_input, $output_filename) {
 
   // Set image scale factor.
   $pdf->setImageScale(PDF_IMAGE_SCALE_RATIO);
-
-  // Set some language-dependent strings.
-  $pdf->setLanguageArray($l);
 
   // Set default font subsetting mode.
   $pdf->setFontSubsetting(TRUE);

--- a/modules/exporter/includes/pdf.inc
+++ b/modules/exporter/includes/pdf.inc
@@ -31,9 +31,11 @@
 function citation_exporter_create_pdf($html_input, $output_filename) {
   module_load_include('php', 'citation_exporter', '/lib/tcpdf/config/lang/eng');
   module_load_include('php', 'citation_exporter', '/lib/tcpdf/tcpdf');
-  
+
+  // @codingStandardsIgnoreStart
   // XXX: pull in language array defined inside of the tcpdf config lang file.
   global $l;
+  // @codingStandardsIgnoreEnd
 
   // Create new PDF document.
   $pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, TRUE, 'UTF-8', FALSE, FALSE);

--- a/modules/exporter/includes/pdf.inc
+++ b/modules/exporter/includes/pdf.inc
@@ -29,7 +29,7 @@
  *   The location to save the generated PDF.
  */
 function citation_exporter_create_pdf($html_input, $output_filename) {
-  module_load_include('php', 'citation_exporter', '/lib/tcpdf/config/lang/eng');
+  require_once DRUPAL_ROOT . '/' . drupal_get_path('module', 'citation_exporter') . '/lib/tcpdf/config/lang/eng.php';
   module_load_include('php', 'citation_exporter', '/lib/tcpdf/tcpdf');
 
   // Create new PDF document.


### PR DESCRIPTION
...files the file needs to be included not using module_load_include so that the language array defined stays in accessible scope.
