### PR TITLE
change name/role/roleTerm to xpath

### DIFF
--- a/modules/citeproc/includes/converter.inc
+++ b/modules/citeproc/includes/converter.inc
@@ -305,17 +305,33 @@ function convert_mods_to_citeproc_json_page(SimpleXMLElement $mods) {
   if (empty($pages)) {
     $pages = $mods->xpath("//mods:mods[1]/mods:part/mods:extent[@unit='page']");
   }
-  if (isset($pages[0])) {
-    if (!empty($pages[0]->total)) {
-      $output = (string) $pages[0]->total;
+
+  $pages = (!empty($pages) ? $pages[0] : NULL);
+  if ($pages) {
+    add_mods_namespace($pages);
+
+    $total = $pages->xpath('mods:total');
+    $total = (!empty($total) ? (string) $total[0] : NULL);
+
+    $list = $pages->xpath('mods:list');
+    $list = (!empty($list) ? (string) $list[0] : NULL);
+
+    $start = $pages->xpath('mods:start');
+    $start = (!empty($start) ? (string) $start[0] : NULL);
+
+    $end = $pages->xpath('mods:end');
+    $end = (!empty($end) ? (string) $end[0] : NULL);
+
+    if ($total) {
+      $output = $total;
     }
-    elseif (!empty($pages[0]->list)) {
-      $output = (string) $pages[0]->list;
+    elseif ($list) {
+      $output = $list;
     }
-    elseif (!empty($pages[0]->start)) {
-      $output = (string) $pages[0]->start;
-      if (!empty($pages[0]->end)) {
-        $output .= "-" . $pages[0]->end;
+    elseif ($start) {
+      $output = $start;
+      if ($end) {
+        $output .= "-" . $end;
       }
     }
   }

--- a/modules/citeproc/includes/converter.inc
+++ b/modules/citeproc/includes/converter.inc
@@ -659,18 +659,18 @@ function convert_mods_to_citeproc_json_name_corporate(SimpleXMLElement $name) {
  */
 function convert_mods_to_citeproc_json_name_role(SimpleXMLElement $name, array $valid_roles, $default_role) {
   module_load_include('inc', 'citeproc', 'includes/marcrelator_conversion');
-  $roleTerm = $name->xpath("mods:role/mods:roleTerm");
-  if (isset($roleTerm[0])) {
-    $role = (string) $roleTerm[0];
-    $roleTerm = $roleTerm[0];
+  $role_term = $name->xpath("mods:role/mods:roleTerm");
+  if (isset($role_term[0])) {
+    $role = (string) $role_term[0];
+    $role_term = $role_term[0];
   }
   else {
     $role = NULL;
   }
 
   if ($role) {
-    $role_authority = (string) $roleTerm->attributes()->authority;
-    $role_type = (string) $roleTerm->attributes()->type;
+    $role_authority = (string) $role_term->attributes()->authority;
+    $role_type = (string) $role_term->attributes()->type;
 
     if ($role_authority == 'marcrelator' && $role_type == 'code') {
       $role = marcrelator_code_to_term($role);

--- a/modules/citeproc/includes/converter.inc
+++ b/modules/citeproc/includes/converter.inc
@@ -659,14 +659,21 @@ function convert_mods_to_citeproc_json_name_corporate(SimpleXMLElement $name) {
  */
 function convert_mods_to_citeproc_json_name_role(SimpleXMLElement $name, array $valid_roles, $default_role) {
   module_load_include('inc', 'citeproc', 'includes/marcrelator_conversion');
-  if (isset($name->role)) {
-    $role = strtolower((string) $name->role->roleTerm);
-    if (isset($name->role->roleTerm)) {
-      $role_authority = (string) $name->role->roleTerm->attributes()->authority;
-      $role_type = (string) $name->role->roleTerm->attributes()->type;
-      if ($role_authority == 'marcrelator' && $role_type == 'code') {
-        $role = marcrelator_code_to_term($role);
-      }
+  $roleTerm = $name->xpath("mods:role/mods:roleTerm");
+  if (isset($roleTerm[0])) {
+    $role = (string) $roleTerm[0];
+    $roleTerm = $roleTerm[0];
+  }
+  else {
+    $role = NULL;
+  }
+
+  if ($role) {
+    $role_authority = (string) $roleTerm->attributes()->authority;
+    $role_type = (string) $roleTerm->attributes()->type;
+
+    if ($role_authority == 'marcrelator' && $role_type == 'code') {
+      $role = marcrelator_code_to_term($role);
     }
     return array_key_exists($role, $valid_roles) ? $valid_roles[$role] : FALSE;
   }


### PR DESCRIPTION
simple xml inconsistencies 

This works

```
<mods:name type="personal">
    <mods:namePart type="given">Guizhi</mods:namePart>
    <mods:namePart type="family">Wang</mods:namePart>
    <role>
      <roleTerm authority="marcrelator" type="text">author</roleTerm>
    </role>
  </mods:name>
```

This doesn't work

```
  <mods:name type="personal">
    <mods:namePart type="given">Guizhi</mods:namePart>
    <mods:namePart type="family">Wang</mods:namePart>
    <mods:role>
      <mods:roleTerm authority="marcrelator" type="text">author</mods:roleTerm>
    </mods:role>
  </mods:name>
```
