### PR TITLE
Avoid building MODS edit form with islandora_scholar_add_usage_and_version_elements_to_mods() elements

### DIFF
--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -787,7 +787,7 @@
               <value>physicalDescription</value>
             </create>
             <read>
-              <path>mods:physicalDescription</path>
+              <path>mods:physicalDescription[not(@authority) or @authority != 'local']</path>
               <context>parent</context>
             </read>
             <update>NULL</update>


### PR DESCRIPTION
The upload form (and methods) provided by includes/upload.tab.inc#[islandora_scholar_add_usage_and_version_elements_to_mods()](https://github.com/unb-libraries/islandora_scholar/blob/7.x/includes/upload.tab.inc#L212) add elements to the MODS datastream :

`<mods:accessCondition type="use and reproduction">author</mods:accessCondition>
<mods:physicalDescription authority="local">PUBLISHED</mods:physicalDescription>`

This form will attempt to render those elements when building the form, duplicating the PhysicalDescription block for input.

Adding XPath selectors to the avoids the READ method grabbing the unrelated elements on form build.
