### PR TITLE
Correct error in marcform authority element of thesis form

### DIFF
--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -807,7 +807,7 @@
               <multiple>FALSE</multiple>
               <options>
                 <index key="">select a format</index>
-                <electronc>electronic</electronc>
+                <electronic>electronic</electronic>
                 <print>print</print>
                 <microfiche>microfiche</microfiche>
                 <microfilm>microfilm</microfilm>


### PR DESCRIPTION
The physicalDescription element of the thesis MODS form contains an error that inserts incorrect metadata into MODS.
