### PR TITLE
allow dynamic citations on thesis objects

### DIFF
--- a/includes/csl_select.form.inc
+++ b/includes/csl_select.form.inc
@@ -19,25 +19,27 @@
  *   The Drupal form definition.
  */
 function islandora_scholar_citation_select_form(array $form, array &$form_state, $pid) {
-  return array(
-    'citation_select' => array(
-      '#type' => 'select',
-      '#options' => CSL::GetNames(),
-      '#default_value' => CSL::GetDefaultName(),
-      '#title' => t('Style'),
-      '#description' => t('Choose the citation style.'),
-      '#attached' => array(
-        'js' => array(
-          drupal_get_path('module', 'islandora_scholar') . '/js/citation_select.js',
-          array(
-            'type' => 'setting',
-            'data' => array('islandora_scholar' => array('pid' => $pid)),
+  if (variable_get('islandora_scholar_users_choose_display_csl', FALSE)) {
+    return array(
+      'citation_select' => array(
+        '#type' => 'select',
+        '#options' => CSL::GetNames(),
+        '#default_value' => CSL::GetDefaultName(),
+        '#title' => t('Style'),
+        '#description' => t('Choose the citation style.'),
+        '#attached' => array(
+          'js' => array(
+            drupal_get_path('module', 'islandora_scholar') . '/js/citation_select.js',
+            array(
+              'type' => 'setting',
+              'data' => array('islandora_scholar' => array('pid' => $pid)),
+            ),
           ),
         ),
+        '#attributes' => array(
+          'class' => array('islandora-scholar-citation-select'),
+        ),
       ),
-      '#attributes' => array(
-        'class' => array('islandora-scholar-citation-select'),
-      ),
-    ),
-  );
+    );
+  }
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -40,12 +40,10 @@ function islandora_scholar_get_view(AbstractObject $object) {
     ),
   );
   if (isset($object['MODS']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS'])) {
-    if (variable_get('islandora_scholar_users_choose_display_csl', FALSE)) {
-      module_load_include('inc', 'islandora_scholar', 'includes/csl_select.form');
-      $display['citation_select'] = drupal_get_form('islandora_scholar_citation_select_form', $object->id);
-    }
+    module_load_include('inc', 'islandora_scholar', 'includes/csl_select.form');
+    $display['citation_select'] = drupal_get_form('islandora_scholar_citation_select_form', $object->id);
     $display['citation']['#markup'] = citeproc_bibliography_from_mods(
-        citeproc_default_style(), $object['MODS']->content
+      citeproc_default_style(), $object['MODS']->content
     );
 
     if (variable_get('islandora_scholar_google_scholar_search_enabled', FALSE)) {
@@ -86,13 +84,13 @@ function islandora_scholar_get_view(AbstractObject $object) {
   }
   elseif (isset($object['PREVIEW']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PREVIEW'])) {
     $image = theme('image', array(
-      'path' => "islandora/object/$object->id/datastream/PREVIEW/view",
-    ));
+        'path' => "islandora/object/$object->id/datastream/PREVIEW/view",
+      ));
     if (isset($object['PDF']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PDF'])) {
       $display['preview'] = array(
         '#markup' => l($image, "islandora/object/$object->id/datastream/PDF/view", array(
-          'html' => TRUE,
-        )),
+            'html' => TRUE,
+          )),
         '#weight' => $display['preview']['#weight'],
       );
     }

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -219,7 +219,7 @@ function islandora_scholar_romeo_access($object) {
  */
 function islandora_scholar_citation_access($object) {
   return variable_get('islandora_scholar_users_choose_display_csl', FALSE) &&
-    in_array(('ir:citationCModel' || 'ir:thesisCModel'), $object->models) &&
+    array_intersect(array('ir:citationCModel', 'ir:thesisCModel'), $object->models) &&
     isset($object['MODS']) &&
     islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS']);
 }

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -219,7 +219,7 @@ function islandora_scholar_romeo_access($object) {
  */
 function islandora_scholar_citation_access($object) {
   return variable_get('islandora_scholar_users_choose_display_csl', FALSE) &&
-    in_array('ir:citationCModel', $object->models) &&
+    in_array(('ir:citationCModel' || 'ir:thesisCModel'), $object->models) &&
     isset($object['MODS']) &&
     islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS']);
 }


### PR DESCRIPTION
Dynamic citations for thesis objects weren't working because 'islandora_scholar_citation_access' checks to make sure the object is an ir:citationCModel. Now it allows ir:thesisCModels as well. Tested on the 1.5 release VM.
