### PR TITLE
ISLANDORA-1450: removes double attempt to delete

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -199,7 +199,6 @@ function islandora_scholar_add_jpg_derivative(AbstractObject $object, $file_uri,
       return islandora_scholar_missing_pdf_datastream($object->id);
     }
     $derivative_file_uri = islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $height);
-    file_unmanaged_delete($file_uri);
     // Receive a valid file URI to add or an error message otherwise.
     if (!is_array($derivative_file_uri) && file_valid_uri($derivative_file_uri)) {
       $success = islandora_scholar_add_datastream($object, $dsid, $derivative_file_uri);


### PR DESCRIPTION
Resolves issue for https://jira.duraspace.org/browse/ISLANDORA-1450 by removing the first call to unmanaged file delete, called inside function islandora_scholar_add_jpg_derivative(). Since the path to the file to be deleted is assigned in the caller function, then it makes sense to keep the deletion at that level.
