### PR TITLE
ISLANDORA-1555

### DIFF
--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -6,25 +6,23 @@
  */
 
 /**
- * Get the CrossRef for the given url.
+ * Get the DOI name for the given url.
  *
- * @param string $url
- *   A DOI url, or a DOI number with or without the "doi:" prefix. If the $url
+ * @param string $doi_url
+ *   A DOI url, or a DOI name with or without the "doi:" prefix. If the $url
  *   is a CrossRef ID passed in as doi:10.1016/j.tiv.2011.10.017 or
  *   10.1111/eve.12339 it will not get changed by running it through parse_url.
  *
  * @return string
- *   CrossRef ID string.
+ *   A string containing the DOI name.
  */
-function islandora_doi_get_crossref_id_from_url($url) {
+function islandora_doi_get_doi_name_from_url($doi_url) {
   // Allows for DOI to be entered in the following formats: 10.1111/eva.12339,
   // http://dx.doi.org/10.1111/eva.12339, http://doi.org/10.1111/eva.12339,
-  // or doi:10.1111/eva.12339.
-  $doi_url = parse_url(trim($url));
-  // Remove "/" from the path if it's the first or last character in the path.
-  $doi_url['path'] = rtrim($doi_url['path'], '/');
-  $doi_url['path'] = ltrim($doi_url['path'], '/');
-  return $doi_url['path'];
+  // or doi:10.1111/eva.12339. Removing whitespace before parsing the url and
+  // then removing any trailing "/" from the returned path.
+  $doi_name = trim(parse_url(trim($doi_url), PHP_URL_PATH), '/');
+  return $doi_name;
 }
 
 /**
@@ -38,8 +36,8 @@ function islandora_doi_get_crossref_id_from_url($url) {
  *   An object as provided by drupal_http_request().
  */
 function islandora_doi_perform_request($id_or_url) {
-  // Allows for $id to pass a DOI url string or the Crossref ID.
-  $id = islandora_doi_get_crossref_id_from_url($id_or_url);
+  // Allows for $id to pass a DOI url string or the DOI name.
+  $id = islandora_doi_get_doi_name_from_url($id_or_url);
   $openurl = variable_get('islandora_doi_openurl', 'http://www.crossref.org/openurl');
   $openurl_pid = variable_get('islandora_doi_openurl_pid', 'user@example.com');
   $url = url($openurl, array(

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -6,15 +6,40 @@
  */
 
 /**
+ * Get the CrossRef for the given url.
+ *
+ * @param string $url
+ *   A DOI url, or a DOI number with or without the "doi:" prefix. If the $url
+ *   is a CrossRef ID passed in as doi:10.1016/j.tiv.2011.10.017 or
+ *   10.1111/eve.12339 it will not get changed by running it through parse_url.
+ *
+ * @return string
+ *   CrossRef ID string.
+ */
+function islandora_doi_get_crossref_id_from_url($url) {
+  // Allows for DOI to be entered in the following formats: 10.1111/eva.12339,
+  // http://dx.doi.org/10.1111/eva.12339, http://doi.org/10.1111/eva.12339,
+  // or doi:10.1111/eva.12339.
+  $doi_url = parse_url(trim($url));
+  // Remove "/" from the path if it's the first or last character in the path.
+  $doi_url['path'] = rtrim($doi_url['path'], '/');
+  $doi_url['path'] = ltrim($doi_url['path'], '/');
+  return $doi_url['path'];
+}
+
+/**
  * Perform a request to CrossRef for the given ID.
  *
- * @param string $id
- *   A DOI to lookop. May be provided with or without the "doi:" prefix.
+ * @param string $id_or_url
+ *   A DOI to lookop. May be provided with or without the "doi:" prefix. Can
+ *   also pass a full DOI url (i.e, http://doi.org/10.1111/eva.12339 ).
  *
  * @return object
  *   An object as provided by drupal_http_request().
  */
-function islandora_doi_perform_request($id) {
+function islandora_doi_perform_request($id_or_url) {
+  // Allows for $id to pass a DOI url string or the Crossref ID.
+  $id = islandora_doi_get_crossref_id_from_url($id_or_url);
   $openurl = variable_get('islandora_doi_openurl', 'http://www.crossref.org/openurl');
   $openurl_pid = variable_get('islandora_doi_openurl_pid', 'user@example.com');
   $url = url($openurl, array(

--- a/modules/doi/modules/doi_populator/doi_populator.module
+++ b/modules/doi/modules/doi_populator/doi_populator.module
@@ -19,7 +19,7 @@ function doi_populator_islandora_populator() {
       'doi' => array(
         '#type' => 'textfield',
         '#title' => t('Digital Object Identifier'),
-        '#description' => t('Enter an identifier for which to attempt to acquire metadata, such as: 10.1016/j.jorganchem.2011.11.018, 10.1016/j.tiv.2011.10.017, 10.1111/j.1540-4560.2012.01733.x'),
+        '#description' => t('Enter an identifier for which to attempt to acquire metadata, such as: 10.1016/j.jorganchem.2011.11.018, 10.1016/j.tiv.2011.10.017, 10.1111/j.1540-4560.2012.01733.x, http://dx.doi.org/10.1111/eva.12339, or http://doi.org/10.1111/eva.12340'),
         '#element_validate' => array('doi_populator_validate_id'),
       ),
     ),


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1555
# What does this Pull Request do?

It's an improvement to the DOI to allow for the full DOI URL to be used when getting the DOI data.
# How should this be tested?

Ingest some objects using the DOI importer.  
Old formats should continue to work:
DOI:10.1016/j.jorganchem.2011.11.018
10.1016/eva.12339

In addition to the old formats you should now be able to enter the records using full DOI urls:
http://dx.doi.org/10.1111/eva.12339
http://doi.org/10.1111/eva.12340
# Additional Notes:
- **Could this change impact execution of existing code?** There is no impact on existing code or functions using islandora_doi_perform_request as it maintains backwards compatibility with passing/processing just the CrossRef ID.

**Tagging:** @qadan, @ruebot, @DiegoPino, @mjordan 

---

Matthew Perry
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
