### PR TITLE
ISLANDORA-1552 - added ability for admins to specify use permissions and document versions available during PDF upload

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -112,6 +112,44 @@ function islandora_scholar_admin_form() {
     '#default_value' => variable_get('islandora_scholar_users_choose_display_csl', FALSE),
   );
 
+  $form['islandora_scholar_specify_document_versions'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Specify Document Versions'),
+    '#description' => t('Use your own document versions when uploading a PDF'),
+    '#default_value' => variable_get('islandora_scholar_specify_document_versions', FALSE),
+  );
+
+  $form['islandora_scholar_document_versions'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Document Versions'),
+    '#description' => t('Enter the document versions you would like to choose from. Enter one choice per line.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_specify_document_versions"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#default_value' => variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record"),
+  );
+
+  $form['islandora_scholar_specify_use_permissions'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Specify Use Permissions'),
+    '#description' => t('Use your own use permissions when uploading a PDF'),
+    '#default_value' => variable_get('islandora_scholar_specify_use_permissions', FALSE),
+  );
+
+  $form['islandora_scholar_use_permissions'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Use Permissions'),
+    '#description' => t('Enter the use permissions you would like to choose from. Enter one choice per line.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_specify_use_permissions"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#default_value' => variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor"),
+  );
+
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_scholar_viewers', 'application/pdf');
 

--- a/includes/pdf_upload.form.inc
+++ b/includes/pdf_upload.form.inc
@@ -20,30 +20,10 @@ function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
 
   // Pull document versions from the module settings if available.
-  if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
-    $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
-    $document_versions = array_combine($document_version_names, $document_version_names);
-  }
-  else {
-    $document_versions = array(
-      'PRE-PUBLICATION' => t('Pre-Publication'),
-      'PUBLISHED' => t('Published'),
-      'POST-PUBLICATION' => t('Post-Publication'),
-      'OTHER' => t('Other'),
-    );
-  }
+  $document_versions = get_document_versions();
 
   // Pull use permissions from the module settings if available.
-  if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
-    $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
-    $use_permissions = array_combine($use_permission_names, $use_permission_names);
-  }
-  else {
-    $use_permissions = array(
-      'publisher' => t('Contact Publisher (I do not hold copyright).'),
-      'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
-    );
-  }
+  $use_permissions = get_use_permissions();
 
   $form['upload_pdf_checkbox'] = array(
     '#type' => 'checkbox',

--- a/includes/pdf_upload.form.inc
+++ b/includes/pdf_upload.form.inc
@@ -19,7 +19,7 @@
 function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
 
-  // Pull document versions from the module settings if available
+  // Pull document versions from the module settings if available.
   if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
     $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
     $document_versions = array_combine($document_version_names, $document_version_names);
@@ -33,7 +33,7 @@ function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
     );
   }
 
-  // Pull use permissions from the module settings if available
+  // Pull use permissions from the module settings if available.
   if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
     $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
     $use_permissions = array_combine($use_permission_names, $use_permission_names);

--- a/includes/pdf_upload.form.inc
+++ b/includes/pdf_upload.form.inc
@@ -18,6 +18,33 @@
  */
 function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
+
+  // pull document versions from the module settings if available
+  if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
+    $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
+    $document_versions = array_combine($document_version_names, $document_version_names);
+  }
+  else {
+    $document_versions = array(
+      'PRE-PUBLICATION' => t('Pre-Publication'),
+      'PUBLISHED' => t('Published'),
+      'POST-PUBLICATION' => t('Post-Publication'),
+      'OTHER' => t('Other'),
+    );
+  }
+
+  // pull use permissions from the module settings if available
+  if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
+    $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
+    $use_permissions = array_combine($use_permission_names, $use_permission_names);
+  }
+  else {
+    $use_permissions = array(
+      'publisher' => t('Contact Publisher (I do not hold copyright).'),
+      'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
+    );
+  }
+
   $form['upload_pdf_checkbox'] = array(
     '#type' => 'checkbox',
     '#title' => t('Would you like to include a PDF document for this citation?'),
@@ -43,20 +70,12 @@ function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
   $form['upload_document']['version'] = array(
     '#type' => 'radios',
     '#title' => t('Document Version'),
-    '#options' => array(
-      'PRE-PUBLICATION' => t('Pre-Publication'),
-      'PUBLISHED' => t('Published'),
-      'POST-PUBLICATION' => t('Post-Publication'),
-      'OTHER' => t('Other'),
-    ),
+    '#options' => $document_versions,
   );
   $form['upload_document']['usage'] = array(
     '#type' => 'radios',
     '#title' => t('Use Permission'),
-    '#options' => array(
-      'publisher' => t('Contact Publisher (I do not hold copyright).'),
-      'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
-    ),
+    '#options' => $use_permissions,
   );
   $form['upload_document']['certifying'] = array(
     '#type' => 'checkboxes',

--- a/includes/pdf_upload.form.inc
+++ b/includes/pdf_upload.form.inc
@@ -19,7 +19,7 @@
 function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
 
-  // pull document versions from the module settings if available
+  // Pull document versions from the module settings if available
   if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
     $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
     $document_versions = array_combine($document_version_names, $document_version_names);
@@ -33,7 +33,7 @@ function islandora_scholar_pdf_upload_form(array $form, array &$form_state) {
     );
   }
 
-  // pull use permissions from the module settings if available
+  // Pull use permissions from the module settings if available
   if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
     $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
     $use_permissions = array_combine($use_permission_names, $use_permission_names);

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -137,31 +137,13 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
   };
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
 
+  module_load_include('inc', 'islandora_scholar', 'includes/utilities');
+
   // Pull document versions from the module settings if available.
-  if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
-    $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
-    $document_versions = array_combine($document_version_names, $document_version_names);
-  }
-  else {
-    $document_versions = array(
-      'PRE-PUBLICATION' => t('Pre-Publication'),
-      'PUBLISHED' => t('Published'),
-      'POST-PUBLICATION' => t('Post-Publication'),
-      'OTHER' => t('Other'),
-    );
-  }
+  $document_versions = get_document_versions();
 
   // Pull use permissions from the module settings if available.
-  if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
-    $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
-    $use_permissions = array_combine($use_permission_names, $use_permission_names);
-  }
-  else {
-    $use_permissions = array(
-      'publisher' => t('Contact Publisher (I do not hold copyright).'),
-      'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
-    );
-  }
+  $use_permissions = get_use_permissions();
 
   return array(
     '#type' => 'form',

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -136,6 +136,33 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : $default;
   };
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
+
+  // pull document versions from the module settings if available
+  if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
+    $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
+    $document_versions = array_combine($document_version_names, $document_version_names);
+  }
+  else {
+    $document_versions = array(
+      'PRE-PUBLICATION' => t('Pre-Publication'),
+      'PUBLISHED' => t('Published'),
+      'POST-PUBLICATION' => t('Post-Publication'),
+      'OTHER' => t('Other'),
+    );
+  }
+
+  // pull use permissions from the module settings if available
+  if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
+    $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
+    $use_permissions = array_combine($use_permission_names, $use_permission_names);
+  }
+  else {
+    $use_permissions = array(
+      'publisher' => t('Contact Publisher (I do not hold copyright).'),
+      'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
+    );
+  }
+
   return array(
     '#type' => 'form',
     'upload_document' => array(
@@ -163,21 +190,13 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
       'version' => array(
         '#type' => 'radios',
         '#title' => t('Document Version'),
-        '#options' => array(
-          'PRE-PUBLICATION' => t('Pre-Publication'),
-          'PUBLISHED' => t('Published'),
-          'POST-PUBLICATION' => t('Post-Publication'),
-          'OTHER' => t('Other'),
-        ),
+        '#options' => $document_versions,
         '#required' => TRUE,
       ),
       'usage' => array(
         '#type' => 'radios',
         '#title' => t('Use Permission'),
-        '#options' => array(
-          'publisher' => t('Contact Publisher (I do not hold copyright).'),
-          'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
-        ),
+        '#options' => $use_permissions,
         '#required' => TRUE,
       ),
       'certifying' => array(

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -137,7 +137,7 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
   };
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
 
-  // Pull document versions from the module settings if available
+  // Pull document versions from the module settings if available.
   if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
     $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
     $document_versions = array_combine($document_version_names, $document_version_names);
@@ -151,7 +151,7 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
     );
   }
 
-  // Pull use permissions from the module settings if available
+  // Pull use permissions from the module settings if available.
   if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
     $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
     $use_permissions = array_combine($use_permission_names, $use_permission_names);

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -137,7 +137,7 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
   };
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
 
-  // pull document versions from the module settings if available
+  // Pull document versions from the module settings if available
   if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
     $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
     $document_versions = array_combine($document_version_names, $document_version_names);
@@ -151,7 +151,7 @@ function islandora_scholar_upload_form(array $form, array &$form_state, Abstract
     );
   }
 
-  // pull use permissions from the module settings if available
+  // Pull use permissions from the module settings if available
   if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
     $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
     $use_permissions = array_combine($use_permission_names, $use_permission_names);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -209,3 +209,39 @@ function islandora_scholar_get_metadata_display($object, $weight) {
   }
   return $display;
 }
+
+/**
+ * Get a list of document versions for PDF upload either from the module
+ * settings or, if not set, a default list.
+ */
+function get_document_versions() {
+  if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
+    $document_version_names = array_map('trim', explode("\n", variable_get('islandora_scholar_document_versions', "Author's Original\nSubmitted Manuscript Under Review\nAccepted Manuscript\nProof\nVersion of Record\nCorrected Version of Record\nEnhanced Version of Record")));
+    return array_combine($document_version_names, $document_version_names);
+  }
+  else {
+    return array(
+      'PRE-PUBLICATION' => t('Pre-Publication'),
+      'PUBLISHED' => t('Published'),
+      'POST-PUBLICATION' => t('Post-Publication'),
+      'OTHER' => t('Other'),
+    );
+  }
+}
+
+/**
+ * Get a list of use permissions for PDF upload from the module settings or, if
+ * not set, a default list.
+ */
+function get_use_permissions() {
+  if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {
+    $use_permission_names = array_map('trim', explode("\n", variable_get('islandora_scholar_use_permissions', "Publisher\nAuthor")));
+    return array_combine($use_permission_names, $use_permission_names);
+  }
+  else {
+    return array(
+      'publisher' => t('Contact Publisher (I do not hold copyright).'),
+      'author' => t('Contact Author (I hold the copyright and wish to retain all rights).'),
+    );
+  }
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -211,8 +211,7 @@ function islandora_scholar_get_metadata_display($object, $weight) {
 }
 
 /**
- * Get a list of document versions for PDF upload either from the module
- * settings or, if not set, a default list.
+ * Get a list of document versions for PDF upload either from the module settings or, if not set, a default list.
  *
  * @return array
  *   document versions to choose from during document ingest
@@ -233,8 +232,7 @@ function get_document_versions() {
 }
 
 /**
- * Get a list of use permissions for PDF upload from the module settings or, if
- * not set, a default list.
+ * Get a list of use permissions for PDF upload from the module settings or, if not set, a default list.
  *
  * @return array
  *   use permissions to choose from during document ingest

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -211,7 +211,7 @@ function islandora_scholar_get_metadata_display($object, $weight) {
 }
 
 /**
- * Get a list of document versions for PDF upload either from the module settings or, if not set, a default list.
+ * Get a list of document versions for PDF upload.
  *
  * @return array
  *   document versions to choose from during document ingest
@@ -232,7 +232,7 @@ function get_document_versions() {
 }
 
 /**
- * Get a list of use permissions for PDF upload from the module settings or, if not set, a default list.
+ * Get a list of use permissions for PDF upload.
  *
  * @return array
  *   use permissions to choose from during document ingest

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -213,6 +213,9 @@ function islandora_scholar_get_metadata_display($object, $weight) {
 /**
  * Get a list of document versions for PDF upload either from the module
  * settings or, if not set, a default list.
+ *
+ * @return array
+ *   document versions to choose from during document ingest
  */
 function get_document_versions() {
   if (variable_get('islandora_scholar_specify_document_versions', FALSE)) {
@@ -232,6 +235,9 @@ function get_document_versions() {
 /**
  * Get a list of use permissions for PDF upload from the module settings or, if
  * not set, a default list.
+ *
+ * @return array
+ *   use permissions to choose from during document ingest
  */
 function get_use_permissions() {
   if (variable_get('islandora_scholar_specify_use_permissions', FALSE)) {

--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -24,6 +24,10 @@ function islandora_scholar_uninstall() {
   $variables = array(
     'islandora_scholar_use_standard_metadata_display',
     'islandora_scholar_users_choose_display_csl',
+    'islandora_scholar_specify_document_versions',
+    'islandora_scholar_document_versions',
+    'islandora_scholar_specify_use_permissions',
+    'islandora_scholar_use_permissions',
     'islandora_scholar_romeo_enable',
     'islandora_scholar_thumbnail_width',
     'islandora_scholar_thumbnail_height',


### PR DESCRIPTION
In the admin settings you can now toggle whether to use the old values (used by default for backwards compatibility) or to specify your own. If selected you are able to add as many use permissions and document versions as you like, by entering them one per line in a text box. 

Whatever you enter will be both what is displayed to the user and what is stored in the metadata.
