### PR TITLE
Enables roles with "can embargo any object" to manage embargoed items

### DIFF
--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -479,8 +479,8 @@ function islandora_scholar_embargo_set_embargo($param, $dsid = NULL, $end = 'ind
       foreach ($users as $user) {
         $xacml->viewingRule->addUser($user->name);
       }
-      foreach ($roles as $key => $name) {
-        $xacml->viewingRule->addRole($name);
+      foreach ($roles as $key => $role) {
+        $xacml->viewingRule->addRole($role);
       }
     }
   }
@@ -512,8 +512,8 @@ function islandora_scholar_embargo_set_embargo($param, $dsid = NULL, $end = 'ind
         foreach ($users as $user) {
           $xacml->datastreamRule->addUser($user->name);
         }
-        foreach ($roles as $key => $name) {
-          $xacml->datastreamRule->addRole($name);
+        foreach ($roles as $key => $role) {
+          $xacml->datastreamRule->addRole($role);
         }
       }
     }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -462,6 +462,9 @@ function islandora_scholar_embargo_set_embargo($param, $dsid = NULL, $end = 'ind
   $xacml_changed = FALSE;
 
   $users = islandora_scholar_embargo_users_to_notify($item);
+  $roles = user_roles(FALSE, 'can embargo any object');
+  // ISLANDORA_SCHOLAR_EMBARGO_CAN_EMBARGO_ANY
+
   if ($dsid === NULL) {
     $item->relationships->remove(ISLANDORA_SCHOLAR_EMBARGO_RELS_URI, ISLANDORA_SCHOLAR_EMBARGO_EXPIRY_PRED);
     $item->relationships->remove(ISLANDORA_SCHOLAR_EMBARGO_RELS_URI, ISLANDORA_SCHOLAR_EMBARGO_NOTIFICATION_PRED);
@@ -472,9 +475,12 @@ function islandora_scholar_embargo_set_embargo($param, $dsid = NULL, $end = 'ind
       if ($notification !== NULL) {
         $item->relationships->add(ISLANDORA_SCHOLAR_EMBARGO_RELS_URI, ISLANDORA_SCHOLAR_EMBARGO_NOTIFICATION_PRED, $notification, $type);
       }
+      $xacml_changed = TRUE;
       foreach ($users as $user) {
         $xacml->viewingRule->addUser($user->name);
-        $xacml_changed = TRUE;
+      }
+      foreach ($roles as $key => $name) {
+        $xacml->viewingRule->addRole($name);
       }
     }
   }
@@ -505,6 +511,9 @@ function islandora_scholar_embargo_set_embargo($param, $dsid = NULL, $end = 'ind
         $xacml_changed = TRUE;
         foreach ($users as $user) {
           $xacml->datastreamRule->addUser($user->name);
+        }
+        foreach ($roles as $key => $name) {
+          $xacml->datastreamRule->addRole($name);
         }
       }
     }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -462,8 +462,7 @@ function islandora_scholar_embargo_set_embargo($param, $dsid = NULL, $end = 'ind
   $xacml_changed = FALSE;
 
   $users = islandora_scholar_embargo_users_to_notify($item);
-  $roles = user_roles(FALSE, 'can embargo any object');
-  // ISLANDORA_SCHOLAR_EMBARGO_CAN_EMBARGO_ANY
+  $roles = user_roles(FALSE, ISLANDORA_SCHOLAR_EMBARGO_CAN_EMBARGO_ANY);
 
   if ($dsid === NULL) {
     $item->relationships->remove(ISLANDORA_SCHOLAR_EMBARGO_RELS_URI, ISLANDORA_SCHOLAR_EMBARGO_EXPIRY_PRED);


### PR DESCRIPTION
Currently embargoes are implemented by applying XACML policies to objects restricting access to all but administrators and the object's owner. The permission "can embargo any object" provided by the module has the description "User can add or remove embargo on any object in repository", but this is not the case since any role granted this permission is unable to access the object due to the user-centric XACML policy. This pull request adds a check for all roles with the "can embargo any object" permission and adds them to the XACML policy when setting embargoes.

Use case: FSU has several staff at the graduate school who need to be able to manage embargoes independently on ETDs. We created a low-power "embargo_admin" role with just these permissions, and this pull request was required in order for that role to be able to see embargoed objects.
