### PR TITLE
ISLANDORA-1625 use backup xpath if DOI is blank.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -51,15 +51,19 @@ function islandora_scholar_get_view(AbstractObject $object) {
       $mods_xml = simplexml_load_string($object['MODS']->content);
       $mods_xml->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
 
-      // Search for doi for search term.  If exists use it instead of default.
-      $primary_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_primary_search_xpath', NULL));
+      // Search for primary search term (usually DOI).
+      $search_term = NULL;
+      $primary_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_primary_search_xpath', '//mods:identifier[@type="doi"]'));
       if ($primary_search) {
         $search_term = (string) reset($primary_search);
       }
-      else {
-        // Default search term is the title of the citation.
-        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', "$object->label"));
+      if (!$search_term) {
+        // Search for default search term (usually title).
+        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:title'));
         $search_term = (string) reset($default_search);
+      }
+      if (!$search_term) {
+        $search_term = $object->label;
       }
 
       $display['google_scholar_search'] = array(


### PR DESCRIPTION
[Edit to use the new github template!]
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1625
See also: release branch PR #223  
# What does this Pull Request do?

Causes blank DOI nodes in the MODS to not break the "Search for this publication on Google Scholar" link. 
# What's new?

If the DOI (or whatever is selected in the primary xpath) is a blank string, don't search Google Scholar for that string. Instead, fall back to the default xpath (usually title), and if that's blank (or the xpath wasn't found) fall back to the object label. 
# How should this be tested?

Ingest a citation object through the GUI and the standard citation form, and do not give it a DOI. The MODS will have an empty <identifier type="doi"/> node. Enable the Google Scholar link at admin/islandora/solution_pack_config/scholar. If the Google Scholar Primary Search XPath is set at its default value (//mods:identifier[@type="doi"]), notice that the resulting Google Scholar link includes an empty query.

Enable this pull request, and that link should now use the fallback ('default') search query. If that xpath isn't found, or is empty, the label will be used. 
# Interest parties:

@whikloj 
