### PR TITLE
author not appearing in citation when using roleTerm marcrelator codes

### DIFF
--- a/modules/citeproc/includes/marcrelator_conversion.inc
+++ b/modules/citeproc/includes/marcrelator_conversion.inc
@@ -5,6 +5,7 @@
  * This is a mapping for translation from mods to json.
  */
 
+global $_ir_citation_marcrelator_codes; 
 $_ir_citation_marcrelator_codes = array(
   "acp" => "art copyist",
   "act" => "actor",

--- a/modules/citeproc/includes/marcrelator_conversion.inc
+++ b/modules/citeproc/includes/marcrelator_conversion.inc
@@ -5,7 +5,7 @@
  * This is a mapping for translation from mods to json.
  */
 
-global $_ir_citation_marcrelator_codes; 
+global $_ir_citation_marcrelator_codes;
 $_ir_citation_marcrelator_codes = array(
   "acp" => "art copyist",
   "act" => "actor",


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1829)

https://groups.google.com/forum/#!topic/islandora/NNnzrSaay14
# What does this Pull Request do?

Author name not appearing within the citation with using roleTerm marcrelator codes
# What's new?

As discussed in the Google Group, issue appears to be due to a global variable scoping oversight. Code added to rectify scoping problem.
# How should this be tested?

JIRA Ticket includes a sample MODS record.

Two cases to test include MODS records of the form:

Broken - no author in CSL citation
–
<role>
<roleTerm type="code" authority="marcrelator">aut</roleTerm>
</role>
Broken - no author in CSL citation
–
<role>
<roleTerm type="code" authority="marcrelator">aut</roleTerm>
<roleTerm authority="marcrelator" type="text">Author</roleTerm>
</role>
# Additional Notes:
# Interested parties

@DiegoPino 
