### PR TITLE
Strict warning fix.

### DIFF
--- a/modules/islandora_google_scholar/islandora_google_scholar.module
+++ b/modules/islandora_google_scholar/islandora_google_scholar.module
@@ -107,7 +107,8 @@ function islandora_google_scholar_create_meta_tags($object) {
     }
 
     $host_title = $mods_xml->xpath('//mods:relatedItem[@type="host"]//mods:title');
-    $genre = strtolower((string) reset($mods_xml->xpath('//mods:genre')));
+    $genre = $mods_xml->xpath('//mods:genre');
+    $genre = strtolower((string) reset($genre));
     switch ($genre) {
       case 'book section':
       case 'book chapter':


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1863

# What does this Pull Request do?

Nukes a strict warning when adding Google Scholar meta tags to a citation object.

# What's new?
Less warnings.

# How should this be tested?
View a citation with the module enabled.
Notice the warning thrown.
Pull the code.
No more warning.

# Interested parties
@Islandora/7-x-1-x-committers

