### PR TITLE
    Fix SimpleXML Syntax for PHP7

### DIFF
--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -262,7 +262,7 @@ function islandora_doi_transform_to_mods(SimpleXMLElement $doi_xml) {
                 }
                 foreach ($item->resource as $resource) {
                   $mods_identifier = $mods->addChild('identifier');
-                  $mods_identifier->{0} = (string) $resource;
+                  $mods_identifier[0] = (string) $resource;
                   $mods_identifier->addAttribute('type', 'uri');
                 }
                 break;


### PR DESCRIPTION
**JIRA Ticket**: 

https://jira.duraspace.org/browse/ISLANDORA-1886

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

https://github.com/Islandora/islandora_xml_forms/pull/236

# What does this Pull Request do?

Based on the issue with XML forms, I did a search through the rest of the Islandora core modules for other instances where we appends text nodes using SimpleXml. This appears to be the only other instance so we change it as well. 

# What's new?

In PHP5 you could add a text node to a SimpleXmlElement using the syntax `$element->{0} = 'my text'`. This would result in: `<element>my text</element>`.

In PHP7 this gives (the invalid XML): `<element><0>my text</0></element>`. DomDocument chokes on this invalid XML when its imported and then everything falls apart.

Instead in PHP7 you need to use `$element[0] = 'my text'` this results in the correct XML in both PHP5 and PHP7.

# How should this be tested?

Test that DOI transform works correctly under both PHP5 and PHP7.

# Interested parties
@bryjbrown @DonRichards