### PR TITLE
ISLANDORA-1101: Make Google Scholar default xpath more specific

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -66,7 +66,7 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
-  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:title", array(
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:mods[1]/mods:titleInfo/mods:title", array(
     '#type' => 'textfield',
     '#title' => t('Google Scholar Default Search XPath'),
     '#description' => t('The default xpath you want to use to search'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -59,7 +59,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       }
       if (!$search_term) {
         // Search for default search term (usually title).
-        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:title'));
+        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:mods[1]/mods:titleInfo/mods:title'));
         $search_term = (string) reset($default_search);
       }
       if (!$search_term) {


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1101](https://jira.duraspace.org/browse/ISLANDORA-1101)

# What does this Pull Request do?

Replaces the Google Scholar default xpath query ('//mods:title') with a more specific one ('//mods:mods[1]/mods:titleInfo/mods:title'). The original xpath query could match to a title element anywhere in the MODS record (may be nested in `<relatedItem>`, for example) while the new one matches only on a title element inside of a top-level `<titleInfo>` element. 

This is the exact same xpath expression being used on (L31 of islandora_google_scholar.module)[https://github.com/Islandora/islandora_scholar/blob/7.x/modules/islandora_google_scholar/islandora_google_scholar.module#L31] to find the title for meta tag creation.

# What's new?

* Changes '//mods:title' to '//mods:mods[1]/mods:titleInfo/mods:title' on [L69 of islandora_scholar/includes/admin.form.inc](https://github.com/Islandora/islandora_scholar/blob/7.x/includes/admin.form.inc#L69)

# How should this be tested?

* On a fresh VM, check the Scholar config at /admin/islandora/solution_pack_config/scholar
* Check the 'Render Google Scholar Search link' box and verify that '//mods:mods[1]/mods:titleInfo/mods:title' is set for "Google Scholar Default Search XPath"
* Upload a citation with no DOI and verify that the Google Scholar search link works.

# Additional Notes:
I'm not an xpath wizard so I'd feel better if someone who is gave this their blessing before merging. Perhaps @DiegoPino?

# Interested parties
@Islandora/7-x-1-x-committers 
Especially @DonRichards, @DiegoPino and @dmoses 