### PR TITLE
ISLANDORA-1100: Fixes syntax in ISSN counting logic

### DIFF
--- a/includes/romeo.tab.inc
+++ b/includes/romeo.tab.inc
@@ -52,7 +52,7 @@ class RomeoView {
           $mods_xpath->registerNamespace('m', 'http://www.loc.gov/mods/v3');
 
           $issn_results = $mods_xpath->query('//m:identifier[@type="issn" and normalize-space(text())]');
-          if (count($issn_results) > 0) {
+          if ($issn_results->length > 0) {
             $issn = $issn_results->item(0)->textContent;
           }
         }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1100](https://jira.duraspace.org/browse/ISLANDORA-1100)

# What does this Pull Request do?
Fixes the ISSN counting syntax in [RomeoView::getISSN()](https://github.com/Islandora/islandora_scholar/blob/7.x/includes/romeo.tab.inc#L31-L68) that was causing the following error message:
![RomeoView::getISSN() error message](https://jira.duraspace.org/secure/attachment/16842/romeo_error.png)

The error message shown in [ISLANDORA-1100](https://jira.duraspace.org/browse/ISLANDORA-1100) happens when an object with no `<identifier type="issn">` is loaded with 'Enable RoMEO attempts.' checked in the Scholar config (admin/islandora/solution_pack_config/scholar). It only happens when the ISSN isn't cached, so it can be reproduced by ingesting a new object or manually clearing Drupal's cache (but will only happen on the first page load, after running RomeoView::getISSN() once it will be cached and no longer produce the error).

When Scholar tries to get the ISSN from a record, [line 55](https://github.com/Islandora/islandora_scholar/blob/7.x/includes/romeo.tab.inc#L55) incorrectly tries to determine if there was a match or not. The current behavior runs `(count($issn_results) > 0)` to check to see if the xpath query got at least one match, but this expression will always return true because the xpath result is a DOMNodeList object, not an array. Since it isnt an array, a count on it returns 1 and it moves on to the next line where its trying to get the nonexistent value from the result, hence the error message.

The replacement line, `($issn_results->length > 0)`, should get the proper number of results so that the next line only fires when there really are no ISSNs.

# What's new?
Simple change in an if statement on [line 55](https://github.com/bryjbrown/islandora_scholar/blob/ISLANDORA-1100/includes/romeo.tab.inc#L55) of islandora_scholar/includes/romeo.tab.inc from `(count($issn_results) > 0)` to `($issn_results->length > 0)`.

# How should this be tested?
Enable Romeo attempts from the Scholar config screen and then load a new object with no `<identifier type='issn'>`. On the current branch, you should see an error message from RomeoView::getISSN() on the very first view (subsequent views won't trigger it because its cached), and you can trigger the error again by clearing the cache and re-viewing the object.

Switching to the ISLANDORA-1100 branch, clearing the cache and re-viewing the object should not trigger an error.


# Interested parties
@Islandora/7-x-1-x-committers, @DonRichards (co-maintainer), @dmoses (error reporter)
