### PR TITLE
Reapply batch processes more than 10 objects.

### DIFF
--- a/modules/islandora_scholar_embargo/includes/batch.inc
+++ b/modules/islandora_scholar_embargo/includes/batch.inc
@@ -189,7 +189,7 @@ function islandora_scholar_embargo_reapply_embargoes_batch_operation(&$context) 
         ));
       }
       // If the set was empty, $context['finished'] will be 1 anyway.
-      $context['finished'] == $sandbox['completed'] / $sandbox['total'];
+      $context['finished'] = $sandbox['completed'] / $sandbox['total'];
     }
     if ($context['finished'] >= 1) {
       drupal_set_message(t('Re-applied embargoes to @total objects.', array(

--- a/modules/islandora_scholar_embargo/includes/embargo.inc
+++ b/modules/islandora_scholar_embargo/includes/embargo.inc
@@ -503,7 +503,7 @@ WHERE {
 EOQ;
   // Offset if asked.
   if ($slice_params) {
-    $current_embargo .= "FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?obj) > xs:string('info:fedora/{$slice_params['offset_date']}')))";
+    $current_embargo .= "FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?obj) > xs:string('info:fedora/{$slice_params['offset_pid']}')))";
   }
   $current_embargo .= <<<EOQ
 }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.install
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.install
@@ -28,3 +28,10 @@ function islandora_scholar_embargo_update_7001() {
     an overloading bulk embargo lifting operation during the next cron.  Cron
     should be disable while it is ran.');
 }
+
+/**
+ * Reapply embargo batch previously missing objects.
+ */
+function islandora_scholar_embargo_update_7002() {
+  return t('This update fixes a bug where embargoed objects were potentially missed when attempting to re-apply embargoes when a new role was added. As such, it is advisable to re-run this process through the UI or the "islandora_scholar_embargo_reapply_embargoes" drush command.');
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1908

# What does this Pull Request do?
Reapply scholar embargo batches now process more than 10 objects before exiting.

# What's new?
Batch operates correctly.

# How should this be tested?
Go to admin/islandora/solution_pack_config/embargo/roles
Reapply embargoes on a site that has > 10 objects embargoed.
Note that only 10 of the n objects get reapplied.
Pull code, note that all objects are reapplied.

# Additional Notes:
There likely needs to be some communication / announcement / light brought up to this issue as it could leave the repository in an unexpected state in the event a role was added and this batch ran previously. 

# Interested parties
@Islandora/7-x-1-x-committers, @bryjbrown, @DiegoPino
