### PR TITLE
ISLANDORA-1911 - update sub-module readme maintainer

### DIFF
--- a/modules/doi/modules/doi_importer/README.md
+++ b/modules/doi/modules/doi_importer/README.md
@@ -28,7 +28,7 @@ Current maintainers:
 
 ## Development
 
-If you would like to contribute to this module, please check out our helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the Islandora.ca site.
+If you would like to contribute to this module, please check out [CONTRIBUTING.md](CONTRIBUTING.md). In addition, we have helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the [Islandora.ca](http://islandora.ca) site.
 
 ## License
 

--- a/modules/doi/modules/doi_importer/README.md
+++ b/modules/doi/modules/doi_importer/README.md
@@ -23,7 +23,8 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [discoverygarden](https://github.com/discoverygarden)
+* [Bryan Brown](https://github.com/bryjbrown)
+* [Don Richards](https://github.com/DonRichards)
 
 ## Development
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1911

# What does this Pull Request do?

Deep within Islandora Scholar submodule readmes lurked a reference to a company (discoverygarden) as a maintainer, which isn't really something we do, so this updates the maintainer on the DOI importer readme to match up with the parent module.

Also updates Development section to the newest template.

Part of a larger audit to catch places where discovergarden's contributions have carried over old links or references that should be correct.

# How should this be tested?

Compare the maintainers in this readme to the readme on the [parent module](https://github.com/Islandora/islandora_scholar/blob/7.x/README.md) or the [release team spreadsheet](https://docs.google.com/spreadsheets/d/1PRv2Xo-sNE_sDJHUT5OvTXmNiSHnkdJgwo7VsFkIUgY)

# Interested parties
@DiegoPino or maintainer @DonRichards & @bryjbrown 
