### PR TITLE
ISLANDORA-1013 Allow Admin to toggle default embargo notifications

### DIFF
--- a/modules/islandora_scholar_embargo/includes/admin.form.inc
+++ b/modules/islandora_scholar_embargo/includes/admin.form.inc
@@ -37,6 +37,12 @@ function islandora_embargo_admin(array $form, array &$form_state) {
     'title' => array('data' => t('Content Model')),
   );
   $form = array();
+  $form['email'] = array(
+    '#type' => 'checkbox',
+    '#title' => 'Use default email notifications for embargoes',
+    '#description' => 'Uncheck if you would like to manually set up notifications using rules, or by implementing hook_islandora_scholar_embargo_users_to_notify()',
+    '#default_value' => variable_get('islandora_scholar_embargo_default_emails', TRUE),
+  );
   $form['intro'] = array(
     '#type' => 'item',
     '#title' => 'Select Content Models for objects to be embargoed',
@@ -77,10 +83,12 @@ function islandora_embargo_admin_submit(array $form, array &$form_state) {
   switch ($op) {
     case 'Reset to default':
       variable_del('islandora_embargo_content_models');
+      variable_del('islandora_scholar_embargo_default_emails');
       break;
 
     default:
       $enabled = array_filter($form_state['values']['the_table']);
       variable_set('islandora_embargo_content_models', $enabled);
+      variable_set('islandora_scholar_embargo_default_emails', $form_state['values']['email']);
   }
 }

--- a/modules/islandora_scholar_embargo/includes/admin.form.inc
+++ b/modules/islandora_scholar_embargo/includes/admin.form.inc
@@ -39,9 +39,9 @@ function islandora_embargo_admin(array $form, array &$form_state) {
   $form = array();
   $form['email'] = array(
     '#type' => 'checkbox',
-    '#title' => 'Use default email notifications for embargoes',
-    '#description' => 'Uncheck if you would like to manually set up notifications using rules, or by implementing hook_islandora_scholar_embargo_users_to_notify()',
-    '#default_value' => variable_get('islandora_scholar_embargo_default_emails', TRUE),
+    '#title' => 'Suppress default email notifications for embargoes',
+    '#description' => 'Check if you have custom embargo notifications and would like to stop the default email notifications from sending.',
+    '#default_value' => variable_get('islandora_scholar_embargo_suppress_default_emails', FALSE),
   );
   $form['intro'] = array(
     '#type' => 'item',
@@ -83,12 +83,12 @@ function islandora_embargo_admin_submit(array $form, array &$form_state) {
   switch ($op) {
     case 'Reset to default':
       variable_del('islandora_embargo_content_models');
-      variable_del('islandora_scholar_embargo_default_emails');
+      variable_del('islandora_scholar_embargo_suppress_default_emails');
       break;
 
     default:
       $enabled = array_filter($form_state['values']['the_table']);
       variable_set('islandora_embargo_content_models', $enabled);
-      variable_set('islandora_scholar_embargo_default_emails', $form_state['values']['email']);
+      variable_set('islandora_scholar_embargo_suppress_default_emails', $form_state['values']['email']);
   }
 }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.install
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.install
@@ -12,7 +12,7 @@ function islandora_scholar_embargo_uninstall() {
   $variables = array(
     'islandora_embargo_content_models',
     'islandora_scholar_embargo_whitelisted_roles',
-    'islandora_scholar_embargo_default_emails',
+    'islandora_scholar_embargo_suppress_default_emails',
   );
   array_walk($variables, 'variable_del');
 }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.install
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.install
@@ -12,6 +12,7 @@ function islandora_scholar_embargo_uninstall() {
   $variables = array(
     'islandora_embargo_content_models',
     'islandora_scholar_embargo_whitelisted_roles',
+    'islandora_scholar_embargo_default_emails',
   );
   array_walk($variables, 'variable_del');
 }

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -329,12 +329,19 @@ EOQ;
  * Implements hook_islandora_scholar_embargo_users_to_notify().
  */
 function islandora_scholar_embargo_islandora_scholar_embargo_users_to_notify(AbstractObject $object) {
-  $users = array(user_load(1));
-  $owner = $object->owner;
-  $owner = is_numeric($owner) ? user_load($owner) : user_load_by_name($owner);
-  if ($owner) {
-    $users[] = $owner;
+  if (variable_get('islandora_scholar_embargo_default_emails', TRUE)) {
+    $users = array(user_load(1));
+    $owner = $object->owner;
+    $owner = is_numeric($owner) ? user_load($owner) : user_load_by_name($owner);
+    if ($owner) {
+      $users[] = $owner;
+    }
   }
+
+  else {
+    $users = array();
+  }
+
   return $users;
 }
 

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -329,7 +329,7 @@ EOQ;
  * Implements hook_islandora_scholar_embargo_users_to_notify().
  */
 function islandora_scholar_embargo_islandora_scholar_embargo_users_to_notify(AbstractObject $object) {
-  if (variable_get('islandora_scholar_embargo_default_emails', TRUE)) {
+  if (!variable_get('islandora_scholar_embargo_suppress_default_emails', FALSE)) {
     $users = array(user_load(1));
     $owner = $object->owner;
     $owner = is_numeric($owner) ? user_load($owner) : user_load_by_name($owner);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1013

# What does this Pull Request do?

Adds a checkbox to the admin form for the embargo module (admin/islandora/solution_pack_config/embargo) which allows Admin to turn off the default embargo emails. This allows Admin to create their own embargo notifications by using the Rules module, or implementing hook_islandora_scholar_embargo_users_to_notify() themselves.

# What's new?

Just the new variable which edits the behavior in islandora_scholar_embargo_islandora_scholar_embargo_users_to_notify(AbstractObject $object)

# How should this be tested?

Visit the admin form and try lifting embargoes with the checkbox toggled both to true and to false.

# Additional Notes:

We may wish to add to the documentation to explain how to create your own notifications if turning the defaults off.

# Interested parties
@Islandora/7-x-1-x-committers
