### PR TITLE
Update phpunit test cases to use new namespaced functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: required
 language: php
 php:
-  - 5.3.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
 language: php
 php:
+  - 5.3
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -38,6 +41,8 @@ before_install:
 before_script:
   # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
+  - composer require phpunit/phpunit '>=4.8.35|>=5.4.3.,<=5.0'
+  - composer install
 script:
   - ant -buildfile sites/all/modules/islandora_scholar/build.xml lint
   - sites/all/modules/islandora_scholar/tests/scripts/line_endings.sh sites/all/modules/islandora_scholar
@@ -62,4 +67,4 @@ script:
   - mv $HOME/tcpdf $TRAVIS_BUILD_DIR/modules/exporter/lib/
   - cp -Rv $JAVASCRIPT_DIR/* $TRAVIS_BUILD_DIR
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_scholar
-  - phpunit sites/all/modules/islandora_scholar/modules/citeproc/tests/CSL_Dateparser.test
+  - vendor/bin/phpunit sites/all/modules/islandora_scholar/modules/citeproc/tests/CSL_Dateparser.test

--- a/modules/citeproc/tests/CSL_Dateparser.test
+++ b/modules/citeproc/tests/CSL_Dateparser.test
@@ -6,12 +6,14 @@
 
 require_once dirname(__FILE__) . '/../includes/CSLDateparser.php';
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for CSLDateParser.
  * @todo check out what the toArray test was testing and make a test using the
  * class interface.
  */
-class CSLDateParserTest extends PHPUnit_Framework_TestCase {
+class CSLDateParserTest extends TestCase {
   /**
    * Clean up and set default used in tests.
    */


### PR DESCRIPTION
## JIRA Ticket
https://jira.duraspace.org/browse/ISLANDORA-1935

## What does this Pull Request do?

Update to use namespaces in PHP unit so tests with PHP7 don't fail.

Some good info here:
https://thephp.cc/news/2017/02/migrating-to-phpunit-6

> While PHPUnit 5.7 has a forward compatibility layer, meaning you can already use PHPUnit\Framework\TestCase with that version, there is no backward compatibility layer in PHPUnit 6 that allows you to use

## How should this be tested?

Make sure travis doesn't fail, if it passes we should be all good.

## Interested parties
@DiegoPino 