### PR TITLE
Update README.md - fix typo (release version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module requires the following modules/libraries:
 * [Citeproc](https://github.com/Islandora/islandora_scholar/tree/7.x/modules/citeproc) (included in /modules)
 * [CSL](https://github.com/Islandora/islandora_scholar/tree/7.x/modules/csl) (included in /modules)
 
-Additionally, as this module requires the Citeproc moudle, it is necessary to install the [citeproc-php](https://github.com/Islandora/citeproc-php) library into the `sites/all/libraries` directory, such that the main `CiteProc.php` file is located at `sites/all/libraries/citeproc-php/CiteProc.php`. More information is available in [Citeproc's README.md file](https://github.com/Islandora/islandora_scholar/blob/7.x/modules/citeproc/README.md).
+Additionally, as this module requires the Citeproc module, it is necessary to install the [citeproc-php](https://github.com/Islandora/citeproc-php) library into the `sites/all/libraries` directory, such that the main `CiteProc.php` file is located at `sites/all/libraries/citeproc-php/CiteProc.php`. More information is available in [Citeproc's README.md file](https://github.com/Islandora/islandora_scholar/blob/7.x/modules/citeproc/README.md).
 
 ## Installation
 


### PR DESCRIPTION
# What does this Pull Request do?

Fixes a typo. Release version of #263 

# What's new?
_moudle_ becomes _module_.

# How should this be tested?

Review the change. Confirm that 'moudle' is not a thing in 7.x-1.9 either. 

# Interested parties
@bryjbrown or @DonRichards again
