### PR TITLE
Patch 1

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -88,9 +88,9 @@ function islandora_scholar_admin_form() {
     '#description' => t('Enable Searching in your library discovery layer.'),
   ));
   $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_URL', 'https://american.summon.serialssolutions.com', array(
-  	'#type' => 'textfield',
-  	'#title' => t('Library Catalog Location'),
-    '#description' => t('The search URL for your library\'s discovery layer.'),
+    '#type' => 'textfield',
+    '#title' => t('Library Catalog Location'),
+    '#description' => t('The search URL for your library discovery layer.'),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),
@@ -100,7 +100,7 @@ function islandora_scholar_admin_form() {
   $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_params', '/search?s.q=', array(
     '#type' => 'textfield',
     '#title' => t('Library Search Parameters'),
-    '#description' => t('The search parameters for your library\'s discovery layer. Default configuration for Summon discovery layer is shown.'),
+    '#description' => t('The search parameters for your library discovery layer. Default configuration for Summon discovery layer is shown.'),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -49,6 +49,12 @@ function islandora_scholar_admin_form() {
       '#description' => t('Various parameters used by Google Scholar Search'),
       '#collapsible' => TRUE,
     ),
+    'library_catalog_search' => array(
+      '#type' => 'fieldset',
+      '#title' => t('Library Catalog Search configuration'),
+      '#description' => t('Various parameters used by your Library Catalog'),
+      '#collapsible' => TRUE,
+    ),
   );
 
   $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_search_enabled', FALSE, array(
@@ -66,7 +72,7 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
-  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:mods[1]/mods:titleInfo/mods:title", array(
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:title", array(
     '#type' => 'textfield',
     '#title' => t('Google Scholar Default Search XPath'),
     '#description' => t('The default xpath you want to use to search'),
@@ -76,6 +82,52 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
+  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_enabled', FALSE, array(
+    '#type' => 'checkbox',
+    '#title' => t('Render Library Catalog Search link'),
+    '#description' => t('Enable Searching in your library discovery layer.'),
+  ));
+  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_URL', 'https://american.summon.serialssolutions.com', array(
+  	'#type' => 'textfield',
+  	'#title' => t('Library Catalog Location'),
+    '#description' => t('The search URL for your library\'s discovery layer.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+  ));
+  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_params', '/search?s.q=', array(
+    '#type' => 'textfield',
+    '#title' => t('Library Search Parameters'),
+    '#description' => t('The search parameters for your library\'s discovery layer. Default configuration for Summon discovery layer is shown.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+  ));
+  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_primary_search_xpath', "//mods:identifier[@type=\"doi\"]", array(
+    '#type' => 'textfield',
+    '#title' => t('Library Catalog Primary Search XPath'),
+    '#description' => t('The primary xpath you want to use to search.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+  ));
+  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_default_search_xpath', "//mods:title", array(
+    '#type' => 'textfield',
+    '#title' => t('Library Catalog Default Search XPath'),
+    '#description' => t('The default xpath you want to use to search'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+  ));
+
   $form['romeo'] += _islandora_scholar_add_variable('islandora_scholar_romeo_enable', FALSE, array(
     '#type' => 'checkbox',
     '#title' => t('Enable RoMEO attempts.'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -87,10 +87,10 @@ function islandora_scholar_admin_form() {
     '#title' => t('Render Library Catalog Search link'),
     '#description' => t('Enable Searching in your library discovery layer.'),
   ));
-  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_URL', 'https://american.summon.serialssolutions.com', array(
+  $form['library_catalog_search'] += _islandora_scholar_add_variable('islandora_scholar_library_catalog_search_URL', '', array(
     '#type' => 'textfield',
     '#title' => t('Library Catalog Location'),
-    '#description' => t('The search URL for your library discovery layer.'),
+    '#description' => t('The search URL for your library discovery layer. Example: https://yoursite.discoveryservice.serviceprovider.com'),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_scholar_library_catalog_search_enabled"]' => array('checked' => TRUE),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -72,7 +72,7 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
-  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:title", array(
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:mods[1]/mods:titleInfo/mods:title", array(
     '#type' => 'textfield',
     '#title' => t('Google Scholar Default Search XPath'),
     '#description' => t('The default xpath you want to use to search'),
@@ -135,7 +135,7 @@ function islandora_scholar_admin_form() {
   ));
   $form['romeo'] += _islandora_scholar_add_variable('islandora_scholar_romeo_url', 'http://www.sherpa.ac.uk/romeo/api29.php', array(
     '#title' => t('Sherpa/RoMEO URL'),
-    '#description' => t('The URL to which to make requests.'),
+    '#description' => t('The URL to which to make requests. Default is http://www.sherpa.ac.uk/romeo/api29.php'),
   ));
   $form['romeo'] += _islandora_scholar_add_variable('islandora_scholar_romeo_key', '', array(
     '#title' => t('Sherpa/RoMEO API Key'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -59,7 +59,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       }
       if (!$search_term) {
         // Search for default search term (usually title).
-        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:title'));
+        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:mods[1]/mods:titleInfo/mods:title'));
         $search_term = (string) reset($default_search);
       }
       if (!$search_term) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -77,10 +77,10 @@ function islandora_scholar_get_view(AbstractObject $object) {
       // Library Catalog Search.
       $mods_xml = simplexml_load_string($object['MODS']->content);
       $mods_xml->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
-      // Search for library search URL
+      // Search for library search URL.
       $search_url = NULL;
       $search_url = variable_get('islandora_scholar_library_catalog_search_URL', 'https://american.summon.serialssolutions.com');
-      // Search for library search parameters
+      // Search for library search parameters.
       $search_params = NULL;
       $search_params = variable_get('islandora_scholar_library_catalog_search_params', '/search?s.q=');
       // Search for primary search term (usually DOI).

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -59,7 +59,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       }
       if (!$search_term) {
         // Search for default search term (usually title).
-        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:mods[1]/mods:titleInfo/mods:title'));
+        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_google_scholar_default_search_xpath', '//mods:title'));
         $search_term = (string) reset($default_search);
       }
       if (!$search_term) {
@@ -69,6 +69,38 @@ function islandora_scholar_get_view(AbstractObject $object) {
       $display['google_scholar_search'] = array(
         '#type' => 'item',
         '#markup' => l(t('Search for this publication on Google Scholar'), "http://scholar.google.ca/scholar?q=\"$search_term\""),
+        '#weight' => 0,
+      );
+    }
+
+    if (variable_get('islandora_scholar_library_catalog_search_enabled', FALSE)) {
+      // Library Catalog Search.
+      $mods_xml = simplexml_load_string($object['MODS']->content);
+      $mods_xml->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
+      // Search for library search URL
+      $search_url = NULL;
+      $search_url = variable_get('islandora_scholar_library_catalog_search_URL', 'https://american.summon.serialssolutions.com');
+      // Search for library search parameters
+      $search_params = NULL;
+      $search_params = variable_get('islandora_scholar_library_catalog_search_params', '/search?s.q=');
+      // Search for primary search term (usually DOI).
+      $search_term = NULL;
+      $primary_search = $mods_xml->xpath("" . variable_get('islandora_scholar_library_catalog_primary_search_xpath', '//mods:identifier[@type="doi"]'));
+      if ($primary_search) {
+        $search_term = (string) reset($primary_search);
+      }
+      if (!$search_term) {
+        // Search for default search term (usually title).
+        $default_search = $mods_xml->xpath("" . variable_get('islandora_scholar_library_catalog_default_search_xpath', '//mods:title'));
+        $search_term = (string) reset($default_search);
+      }
+      if (!$search_term) {
+        $search_term = $object->label;
+      }
+
+      $display['library_catalog_search'] = array(
+        '#type' => 'item',
+        '#markup' => l(t('Search for this publication in your library discovery service'), "$search_url$search_params\"$search_term\""),
         '#weight' => 0,
       );
     }

--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -40,6 +40,14 @@ function islandora_scholar_uninstall() {
     'islandora_scholar_romeo_cache_time',
     'islandora_scholar_create_fulltext',
     'islandora_scholar_preview_density',
+    'islandora_scholar_google_scholar_search_enabled',
+    'islandora_scholar_google_scholar_primary_search_xpath',
+    'islandora_scholar_google_scholar_default_search_xpath',
+    'islandora_scholar_library_catalog_search_enabled',
+    'islandora_scholar_library_catalog_search_URL',
+    'islandora_scholar_library_catalog_search_params',
+    'islandora_scholar_library_catalog_primary_search_xpath',
+    'islandora_scholar_library_catalog_default_search_xpath',
   );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
This pull request adds functionality improved on and referenced in this discussion:

https://groups.google.com/forum/#!topic/islandora/EwWeXNJ-dlk

This code adds configuration for a simple catalog search text to appear beneath the Google Scholar search text.  It is configurable in much the same way and also requires changes to utilities.inc in this directory.

It provides a way to query a discovery layer without needing an outside block or additional modules.

# How should this be tested?

This can be tested by adding the required configurations from a known good discovery layer and then testing from a citation object.

# Additional Notes:
This should not require any substantive change to the documentation.  It's pretty self-explanatory.  I improved my first draft so that you can also customize the search parameters, but it provides a good set of defaults for those using the popular Summon platform - that should cover ~30-50% of academic libraries.  So it may not work out of the box for everyone, but is easily configurable for everyone.
