### PR TITLE
change permissions

### DIFF
--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -67,3 +67,10 @@ function islandora_scholar_update_7101(&$sandbox) {
   )));
   watchdog('islandora_scholar', 'Existing mods:physicalDescription fields with an @authority="local" may become hidden with this update.', array(), WATCHDOG_NOTICE, l(t('ISLANDORA-1350'), 'https://jira.duraspace.org/browse/ISLANDORA-1350', array('external' => TRUE)));
 }
+
+/**
+ * Print out a message informing about the change in permissions.
+ */
+function islandora_scholar_update_7102(&$sandbox) {
+  return t('The permission to administer the Islandora Scholar module has been changed to "Administer site configuration"; roles that could previously access Islandora Scholar management pages via the "Use the administration pages and help" permission will no longer be able to do so. Permissions may need to be reviewed.');
+}

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -16,7 +16,7 @@ function islandora_scholar_menu() {
       'type' => MENU_NORMAL_ITEM,
       'page callback' => 'drupal_get_form',
       'page arguments' => array('islandora_scholar_admin_form'),
-      'access arguments' => array('access administration pages'),
+      'access arguments' => array('administer site configuration'),
       'file' => 'includes/admin.form.inc',
     ),
     'admin/islandora/solution_pack_config/scholar/base' => array(
@@ -28,7 +28,7 @@ function islandora_scholar_menu() {
       'type' => MENU_LOCAL_TASK,
       'page callback' => 'drupal_get_form',
       'page arguments' => array('islandora_scholar_admin_pdf_form'),
-      'access arguments' => array('access administration pages'),
+      'access arguments' => array('administer site configuration'),
       'file' => 'includes/admin.form.inc',
     ),
     'islandora/object/%islandora_object/islandora_scholar_romeo' => array(


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1999

# What does this Pull Request do?
Security patch for a form that was a potential target for permissions escalation.

# What's new?
Roles accessing Scholar module site-wide administration pages now require the Administer Site Configuration permission.

# How should this be tested?

This patch has been tested in accordance with the Islandora Security Response Team's workflow.