### PR TITLE
ISLANDORA-1837: Add the nameIdentifier element to the default Citatio…

### DIFF
--- a/xml/citation_form.xml
+++ b/xml/citation_form.xml
@@ -521,6 +521,44 @@
                 </properties>
                 <children/>
               </element>
+              <element name="name_identifier">
+                <properties>
+                  <type>textfield</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <title>Name Identifier</title>
+                  <tree>TRUE</tree>
+                  <actions>
+                    <create>
+                      <path>self::node()</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>xml</type>
+                      <prefix>NULL</prefix>
+                      <value>&lt;nameIdentifier&gt;%value%&lt;/nameIdentifier&gt;</value>
+                    </create>
+                    <read>
+                      <path>mods:nameIdentifier</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>self::node()</path>
+                      <context>self</context>
+                    </update>
+                    <delete>
+                      <path>self::node()</path>
+                      <context>self</context>
+                    </delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
             </children>
           </element>
         </children>

--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -253,6 +253,41 @@
                 </properties>
                 <children/>
               </element>
+              <element name="name_identifier">
+                <properties>
+                  <type>textfield</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <title>Name Identifier</title>
+                  <tree>TRUE</tree>
+                  <actions>
+                    <create>
+                      <path>self::node()</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>xml</type>
+                      <prefix>NULL</prefix>
+                      <value>&lt;nameIdentifier&gt;%value%&lt;/nameIdentifier&gt;</value>
+                    </create>
+                    <read>
+                      <path>mods:nameIdentifier</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>self::node()</path>
+                      <context>self</context>
+                    </update>
+                    <delete>NULL</delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
             </children>
           </element>
         </children>


### PR DESCRIPTION
…n and Thesis forms

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1837

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

This pull request pairs with one made to the islandora_solution_pack_entities module - allowing configuration of Solr field used for linking citation and theses to Person entities.  The MODS name/nameIdentifier field was suggested as a better alternative to name/displayForm.

# What's new?

Addition of name/nameIdentifier to default Citation and Thesis forms.

# How should this be tested?

Create a Citation object.  In the Citation form, under Authors, set a value in the Name Identifier field.  After ingest, view the MODS datastream to verify the value is in the name/nameIdentifier field.  Do the same for a Thesis object.


# Interested parties
@Islandora/7-x-1-x-committers
