### PR TITLE
ISLANDORA-2053: Update travis.yml to force PHP 5.3.3 to run under Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
   - composer self-update
   - composer require phpunit/phpunit '>=4.8.35|>=5.4.3.,<=5.0'
-  - if [[ $(phpenv version-name) = "5.3.3" ]]; composer --prefer-source install; else composer install; fi;
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer --prefer-source install; else composer install; fi;
 script:
   - ant -buildfile sites/all/modules/islandora_scholar/build.xml lint
   - sites/all/modules/islandora_scholar/tests/scripts/line_endings.sh sites/all/modules/islandora_scholar

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,8 @@ env:
 branches:
   only:
     - /^7.x/
-before_install:
-  - composer self-update
-  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi
+before_install: 
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi;
   - cd $HOME
   - mkdir javascript
   - git clone -b 7.x git://github.com/Islandora/islandora.git
@@ -60,8 +59,9 @@ before_install:
 before_script:
   # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
+  - composer self-update
   - composer require phpunit/phpunit '>=4.8.35|>=5.4.3.,<=5.0'
-  - composer install
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; composer --prefer-source install; else composer install; fi;
 script:
   - ant -buildfile sites/all/modules/islandora_scholar/build.xml lint
   - sites/all/modules/islandora_scholar/tests/scripts/line_endings.sh sites/all/modules/islandora_scholar

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
     - /^7.x/
 before_install:
   - composer self-update
-  - if [[ "$TRAVIS_PHP_VERSION" = "5.3.3" ]]; then composer config -g -- disable-tls true | composer config -g -- secure-http false; fi
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false && ; fi
   - cd $HOME
   - mkdir javascript
   - git clone -b 7.x git://github.com/Islandora/islandora.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
     - /^7.x/
 before_install:
   - composer self-update
-  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false && ; fi
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi
   - cd $HOME
   - mkdir javascript
   - git clone -b 7.x git://github.com/Islandora/islandora.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ branches:
   only:
     - /^7.x/
 before_install:
+  - composer self-update
+  - if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then composer config -g -- disable-tls true | composer config -g -- secure-http false; fi
   - cd $HOME
   - mkdir javascript
   - git clone -b 7.x git://github.com/Islandora/islandora.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,37 @@
 sudo: required
+dist: trusty
 language: php
+
+matrix:
+  include:
+   #5.3.3 Ubuntu Precise exceptions
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
-branches:
-  only:
-    - /^7.x/
 env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
+
+branches:
+  only:
+    - /^7.x/
 before_install:
   - cd $HOME
   - mkdir javascript
@@ -68,3 +85,5 @@ script:
   - cp -Rv $JAVASCRIPT_DIR/* $TRAVIS_BUILD_DIR
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_scholar
   - vendor/bin/phpunit sites/all/modules/islandora_scholar/modules/citeproc/tests/CSL_Dateparser.test
+notifications:
+  irc: "irc.freenode.org#islandora"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
     - /^7.x/
 before_install:
   - composer self-update
-  - if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then composer config -g -- disable-tls true | composer config -g -- secure-http false; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "5.3.3" ]]; then composer config -g -- disable-tls true | composer config -g -- secure-http false; fi
   - cd $HOME
   - mkdir javascript
   - git clone -b 7.x git://github.com/Islandora/islandora.git


### PR DESCRIPTION
**ISLANDORA-2053**: (https://jira.duraspace.org/browse/ISLANDORA-2053)
http://irclogs.islandora.ca/2017-09-05.html
https://github.com/travis-ci/travis-ci/issues/2963
https://github.com/Islandora/islandora/pull/683

As of September 2017, Travis-CI has removed support for PHP 5.3 (and 5.2) for their Ubuntu Trusty Images, forcing us, in order  to keep Drupal's compatibility matrix tested, to run Travis-CI test for 5.3 on Ubuntu Precise


# What does this Pull Request do?

This pull Fixes our failing Travis-CI tests: 
Should allow PHP 5.3.3 to run under Ubuntu Precise and Higher versions under Ubuntu Trusty.
Changes the way we define which PHP versions and Fedora ones run in Travis

# What's new?
We moved PHP 5.3.3 version and the corresponding Fedora versions into the matrix section of the Travis YAML file. 


# How should this be tested?
Travis-CI should pass and everything single PHP/FEDORA version combination should look good and very green. On Merge PLEASE SQUASH. (since these are a lot of pulls and I tend to make some typos, I could be pulling more than one commit). Thanks!

# Interested parties
@Islandora/7-x-1-x-committers @bryjbrown @bondjimbond @rosiel 