### PR TITLE
Adjusts menu labels/descriptions

### DIFF
--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -12,7 +12,7 @@ function islandora_scholar_menu() {
   return array(
     'admin/islandora/solution_pack_config/scholar' => array(
       'title' => 'Scholar',
-      'description' => 'Configure scholar settings such as RoMEO and Google Search',
+      'description' => 'Configure Islandora Scholar settings such as RoMEO and Google Search',
       'type' => MENU_NORMAL_ITEM,
       'page callback' => 'drupal_get_form',
       'page arguments' => array('islandora_scholar_admin_form'),

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -26,8 +26,8 @@ function islandora_scholar_embargo_menu() {
     'access arguments' => array(2),
     'file' => 'includes/embargo.inc',
   );
-  $items['admin/islandora/solution_pack_config/embargo'] = array(
-    'title' => 'Scholar Embargo',
+  $items['admin/islandora/tools/embargo'] = array(
+    'title' => 'Islandora Scholar Embargo',
     'description' => 'Configure the Islandora Scholar Embargo module.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_embargo_admin'),

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -27,8 +27,8 @@ function islandora_scholar_embargo_menu() {
     'file' => 'includes/embargo.inc',
   );
   $items['admin/islandora/solution_pack_config/embargo'] = array(
-    'title' => 'Islandora Scholar Embargo',
-    'description' => 'Configure the Embargo module.',
+    'title' => 'Scholar Embargo',
+    'description' => 'Configure the Islandora Scholar Embargo module.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_embargo_admin'),
     'access arguments' => array(ISLANDORA_SCHOLAR_EMBARGO_CAN_EMBARGO_ANY),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1284

# What does this Pull Request do?
Renames "Islandora Scholar Embargoes" to "Scholar Embargoes" in the Islandora Solution Pack menu so that the two appear together, instead of "Islandora Scholar Embargoes" appearing way up the list before "Scholar".

An addition part of this ticket involves a request to put a copy of the "Manage Embargoed Items" inside the Scholar admin menu, but I don't agree with this and didn't implement it. Adding menu tabs for one module into a separate module's admin screen seems messy.

# How should this be tested?
Boot up a VM and go to /admin/islandora/solution_pack_config/. You'll see that "Scholar" and "Scholar Embargoes" now appear next to each other. 

Note: If you booted up with the original Scholar and then switch to this PR, you'll need to clear the cache to rebuild the menu cache.

# Interested parties
@DonRichards @DiegoPino @dmoses @bondjimbond @rosiel 