### PR TITLE
Changes citation/thesis download filename

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -108,10 +108,11 @@ function islandora_scholar_get_view(AbstractObject $object) {
   }
 
   if (isset($object['PDF']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PDF'])) {
+    $filename = str_replace(":", "_", $object->id);
     $display['pdf_download'] = array(
       '#type' => 'item',
       '#title' => t('Download'),
-      '#markup' => l(t('PDF'), "islandora/object/$object->id/datastream/PDF/download/citation.pdf"),
+      '#markup' => l(t('PDF'), "islandora/object/$object->id/datastream/PDF/download/$filename.pdf"),
       '#weight' => $display['pdf_download']['#weight'],
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1805

# What does this Pull Request do?
The current version of Scholar formats download links for citation/thesis cmodels as /islandora/object/PID/datastream/PDF/download/citation.pdf. This could lead to a lot of "citation.pdf" files (or "citation ($).pdf" if your computer automatically renames duplicate filenames) in your downloads folder if you download files from multiple theses/citations.

This PR changes the formatted download link to be "PID.pdf" with the colon swapped to an underscore. This way, if people download PDFs from multiple objects, they can at least keep them apart.

I considered formatting the file name as the object label, but there are too many potential special characters that could lead to weird behavior when used in a filename. This seems safer.

# How should this be tested?
Boot up a VM with this PR and check out a citation/thesis object's "PDF" download link. The link should end in "PID.pdf" instead of "citation.pdf". Download the file to your local machine and check the filename.

# Interested parties
@DonRichards @rosiel @DiegoPino @bondjimbond 