### PR TITLE
ISLANDORA-2172: Take advantage of content negociation capabilities

### DIFF
--- a/modules/doi/README.md
+++ b/modules/doi/README.md
@@ -18,7 +18,11 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 ## Configuration
 
-See admin/islandora/solution_pack_config/scholar/islandora_doi for setting DOI URL, CrossREF URL and registered email.
+By default, no configuration is required.
+
+If you wish to use the legacy CrossREF OpenURL endpoint, you must enable it and enter your "OpenURL PID" at `admin/islandora/solution_pack_config/scholar/islandora_doi`.
+
+It is possible to change the URL against which content negotiation requests are made by changing the "DOI URL supporting content negotiation" URL at `admin/islandora/solution_pack_config/scholar/islandora_doi`.
 
 ## Maintainers/Sponsors
 

--- a/modules/doi/Readme.md
+++ b/modules/doi/Readme.md
@@ -18,7 +18,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 ## Configuration
 
-See admin/islandora/solution_pack_config/scholar/islandora_doi for setting CrossREF URL and registered email.
+See admin/islandora/solution_pack_config/scholar/islandora_doi for setting DOI URL, CrossREF URL and registered email.
 
 ## Maintainers/Sponsors
 

--- a/modules/doi/includes/admin.form.inc
+++ b/modules/doi/includes/admin.form.inc
@@ -21,7 +21,7 @@ function islandora_doi_admin_form(array $form, array &$form_state) {
     'islandora_doi_use_legacy_mode' => array(
       '#type' => 'checkbox',
       '#title' => t('Use legacy retrieval mode'),
-      '#description' => t('Keep fetching metadata directly from CrossREF\'s OpenURL (account required!). If unchecked, use content negociation as explained by https://www.crosscite.org.'),
+      '#description' => t("Keep fetching metadata directly from CrossREF's OpenURL (account required!). If unchecked, use content negociation as explained by https://www.crosscite.org."),
       '#default_value' => variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT),
     ),
     'islandora_doi_url_config' => array(
@@ -35,7 +35,7 @@ function islandora_doi_admin_form(array $form, array &$form_state) {
     'islandora_doi_doiurl' => array(
       '#type' => 'textfield',
       '#title' => t('DOI URL supporting content negociation'),
-      '#description' => t('The URL which we will query in non-legacy mode to obtain our metadata (it is probably not recommended to change this from the default value \'@url\').', array(
+      '#description' => t("The URL which we will query in non-legacy mode to obtain our metadata (it is probably not recommended to change this from the default value '@url').", array(
         '@url' => ISLANDORA_DOI_DOIURL_DEFAULT,
       )),
       '#default_value' => variable_get('islandora_doi_doiurl', ISLANDORA_DOI_DOIURL_DEFAULT),

--- a/modules/doi/includes/admin.form.inc
+++ b/modules/doi/includes/admin.form.inc
@@ -18,17 +18,39 @@
  */
 function islandora_doi_admin_form(array $form, array &$form_state) {
   $form += array(
+    'islandora_doi_use_legacy_mode' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Use legacy retrieval mode'),
+      '#description' => t('Keep fetching metadata directly from CrossREF\'s OpenURL (account required!). If unchecked, use content negociation as explained by https://www.crosscite.org.'),
+      '#default_value' => variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT),
+    ),
+    'islandora_doi_url_config' => array(
+      '#type' => 'fieldset',
+      '#title' => t('DOI URL configuration'),
+      '#description' => t('Various URL related parameters used by the metadata retrieval via DOI.'),
+      '#collapsible' => TRUE,
+    ),
+  );
+  $form['islandora_doi_url_config'] += array(
+    'islandora_doi_doiurl' => array(
+      '#type' => 'textfield',
+      '#title' => t('DOI URL supporting content negociation'),
+      '#description' => t('The URL which we will query in non-legacy mode to obtain our metadata (it is probably not recommended to change this from the default value \'@url\').', array(
+        '@url' => ISLANDORA_DOI_DOIURL_DEFAULT,
+      )),
+      '#default_value' => variable_get('islandora_doi_doiurl', ISLANDORA_DOI_DOIURL_DEFAULT),
+    ),
     'islandora_doi_openurl' => array(
       '#type' => 'textfield',
       '#title' => t('DOI OpenURL'),
-      '#description' => t('The URL which we will query to obtain our CrossREF information.'),
-      '#default_value' => variable_get('islandora_doi_openurl', 'http://www.crossref.org/openurl'),
+      '#description' => t('The URL which we will query in legacy mode to obtain our CrossREF information.'),
+      '#default_value' => variable_get('islandora_doi_openurl', ISLANDORA_DOI_OPENURL_DEFAULT),
     ),
     'islandora_doi_openurl_pid' => array(
       '#type' => 'textfield',
       '#title' => t('OpenURL PID'),
       '#description' => t('An identifier to call yourself, for the OpenURL endpoint. To use this service you first need to register for an account here: http://www.crossref.org/requestaccount/'),
-      '#default_value' => variable_get('islandora_doi_openurl_pid', 'user@example.com'),
+      '#default_value' => variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT),
     ),
   );
 

--- a/modules/doi/includes/admin.form.inc
+++ b/modules/doi/includes/admin.form.inc
@@ -17,12 +17,13 @@
  *   The Drupal form definition.
  */
 function islandora_doi_admin_form(array $form, array &$form_state) {
+  form_load_include($form_state, 'inc', 'islandora_doi', 'includes/utilities');
   $form += array(
     'islandora_doi_use_legacy_mode' => array(
       '#type' => 'checkbox',
       '#title' => t('Use legacy retrieval mode'),
-      '#description' => t("Keep fetching metadata directly from CrossREF's OpenURL (account required!). If unchecked, use content negociation as explained by https://www.crosscite.org."),
-      '#default_value' => variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT),
+      '#description' => t("Keep fetching metadata directly from CrossREF's OpenURL (account required!). If unchecked, use content negotiation as explained by https://www.crosscite.org."),
+      '#default_value' => islandora_doi_use_legacy_mode(),
     ),
     'islandora_doi_url_config' => array(
       '#type' => 'fieldset',
@@ -34,7 +35,7 @@ function islandora_doi_admin_form(array $form, array &$form_state) {
   $form['islandora_doi_url_config'] += array(
     'islandora_doi_doiurl' => array(
       '#type' => 'textfield',
-      '#title' => t('DOI URL supporting content negociation'),
+      '#title' => t('DOI URL supporting content negotiation'),
       '#description' => t("The URL which we will query in non-legacy mode to obtain our metadata (it is probably not recommended to change this from the default value '@url').", array(
         '@url' => ISLANDORA_DOI_DOIURL_DEFAULT,
       )),

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -590,7 +590,7 @@ function islandora_doi_crossref_translator($crossref_xml) {
  *
  * @param string $id
  *   A DOI.
- * @param string $data
+ * @param string $crossref_data
  *   A string containing the data returned by CrossRef for the DOI.
  *
  * @return bool
@@ -642,21 +642,20 @@ function islandora_doi_transform_to_mods($doi_xml, $content_type = 'application/
   global $_islandora_doi_content_translators;
   if (!array_key_exists($content_type, $_islandora_doi_content_translators)) {
     // Warning message: Translator not yet implemented.
-    $err_msg = 'The requested translator for content \'@content_type\' has not yet been implemented. Returning FALSE...';
-    $err_msg_vars = array(
+    watchdog('Islandora DOI', "The requested translator for content '@content_type' has not yet been implemented. Returning FALSE...", array(
       '@content_type' => $content_type,
-    );
-    watchdog('Islandora DOI', $err_msg, $err_msg_vars);
-    trigger_error(t($err_msg, $err_msg_vars));
+    ));
+    trigger_error(t("The requested translator for content '@content_type' has not yet been implemented. Returning FALSE...", array(
+      '@content_type' => check_plain($content_type),
+    )));
     return FALSE;
   }
   // Make sure doi_xml is a DOMDocument. Otherwise show a warning and, if it
   // is a SimpleXMLElement, convert it.
   if ($doi_xml instanceof SimpleXMLElement) {
     // Warning message: Converting from SimpleXMLElement.
-    $err_msg = 'islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.';
-    watchdog('Islandora DOI', $err_msg);
-    trigger_error(t($err_msg));
+    watchdog('Islandora DOI', 'islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.');
+    trigger_error(t('islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.'));
     $dom_xml = new DOMDocument();
     if (!$dom_xml = dom_import_simplexml($doi_xml)) {
       // Error message: Failed to convert from SimpleXMLElement.
@@ -694,7 +693,7 @@ function islandora_doi_get_source($id) {
     if (!$response->data ||
       strpos($headers['content-type'], 'text/html') !== FALSE ||
       strpos($response->data, "Malformed DOI") !== FALSE) {
-      drupal_set_message(t('\'@doi\' does not seem to be a valid CrossREF DOI.', array(
+      drupal_set_message(t("'@doi' does not seem to be a valid CrossREF DOI.", array(
         '@doi' => islandora_doi_get_doi_name_from_url($id),
       )), 'error');
       return FALSE;
@@ -707,39 +706,42 @@ function islandora_doi_get_source($id) {
     if (!$response->data ||
       !isset($response->code) || $response->code != 200 || isset($response->error) ||
       !array_key_exists($headers['content-type'], $_islandora_doi_content_translators)) {
-      $err_406_msg = 'It seems that the metadata provider for \'@doi\' has no content we can handle.';
       if (isset($response->error)) {
         if (isset($response->code) && $response->code == 406) {
           // We should always find ourselves here when the DOI exists but we
           // requested content types the metadata provider does not support.
           // Unfortunately, not all providers behave as expected, which
           // explains the slightly more convoluted construction below.
-          $err_msg = $err_406_msg;
+          drupal_set_message(t("It seems that the metadata provider for '@doi' has no content we can handle.", array(
+            '@doi' => islandora_doi_get_doi_name_from_url($id),
+          )), 'error');
         }
         elseif (isset($response->code) && $response->code == 404) {
           // We would expect this to be the response for invalid DOIs only,
           // but this is not the case...
-          $err_msg = '\'@doi\' does not appear to be a valid DOI';
-          // We know that, e.g., DataCite will return 404 if the first content
-          // type in the Accept header differs from
-          // 'application/vnd.datacite.datacite+xml'. It seems that truly invalid
-          // DOIs get redirected to https://www.doi.org when https://doi.org is
-          // queried.
           if (isset($response->redirect_url) &&
             preg_match('/^https?:\/\/www.doi.org/', $response->redirect_url) !== 1) {
-            $err_msg .= ' (or the metadata provider for this DOI has no content we can handle)';
+            // We know that, e.g., DataCite will return 404 if the first content
+            // type in the Accept header differs from
+            // 'application/vnd.datacite.datacite+xml'. It seems that truly
+            // invalid DOIs get redirected to https://www.doi.org when
+            // https://doi.org is queried.
+            drupal_set_message(t("'@doi' does not appear to be a valid DOI (or the metadata provider for this DOI has no content we can handle).", array(
+              '@doi' => islandora_doi_get_doi_name_from_url($id),
+            )), 'error');
           }
-          $err_msg .= '.';
+          else {
+            drupal_set_message(t("'@doi' does not appear to be a valid DOI.", array(
+              '@doi' => islandora_doi_get_doi_name_from_url($id),
+            )), 'error');
+          }
         }
       }
       elseif (isset($response->code) && $response->code >= 300 && $response->code <= 308 &&
         isset($response->redirect_url)) {
         // The metadata provider tries to redirect us, in all likelyhood to
         // the publisher's website. We treat this the same as 406 above.
-        $err_msg = $err_406_msg;
-      }
-      if (isset($err_msg)) {
-        drupal_set_message(t($err_msg, array(
+        drupal_set_message(t("It seems that the metadata provider for '@doi' has no content we can handle.", array(
           '@doi' => islandora_doi_get_doi_name_from_url($id),
         )), 'error');
       }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -6,6 +6,48 @@
  */
 
 /**
+ * Global variable containing an array, where the keys are acceptable content
+ * types and their values are handler function names for those types. The
+ * functions are supposed to translate the returned XML data into MODS.
+ *
+ * Note: At the time of writing, @link https//doi.org doi.org @endlink was able
+ * to perform the content negociation as explained on
+ * @link https://www.crosscite.org/docs.html crosscite.org. @endlink Since we
+ * are using the array keys to construct the Accept header of the HTTP request,
+ * their order plays a role. So far, the requests alone were tested
+ * simultaneously for @link https://www.crossref.org CrossRef, @endlink
+ * @link https://datacite.org DataCite @endlink and
+ * @link https://www.medra.org mEDRA. @endlink (content types
+ * 'application/vnd.crossref.unixref+xml',
+ * 'application/vnd.datacite.datacite+xml' and
+ * 'application/vnd.medra.onixdoi+xml', respectively). It was noticed that:
+ * - qvalues are not supported (see
+ *   https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
+ * - DataCite will only deliver if its content type comes first.
+ * You may want to take into account those findings when extending this
+ * module to support other metadata providers.
+ */
+global $_islandora_doi_content_translators;
+$_islandora_doi_content_translators = array(
+  'application/vnd.crossref.unixref+xml' => 'islandora_doi_crossref_translator',
+);
+
+/**
+ * Global variable containing an array, where the keys are acceptable content
+ * types and their values are validator function names for those types. The
+ * functions are supposed to validate the string data returned by the metadata
+ * provider, returning TRUE if the content is valid, FALSE otherwise.
+ *
+ * To improve error messages, the function's first argument should be the DOI
+ * of the item to be ingested. For content types that need no validation, just
+ * omit their keys here.
+ */
+global $_islandora_doi_content_validators;
+$_islandora_doi_content_validators = array(
+  'application/vnd.crossref.unixref+xml' => 'islandora_doi_crossref_validator',
+);
+
+/**
  * Get the DOI name for the given url.
  *
  * @param string $doi_url
@@ -26,7 +68,7 @@ function islandora_doi_get_doi_name_from_url($doi_url) {
 }
 
 /**
- * Perform a request to CrossRef for the given ID.
+ * Perform a request to a metadata provider for the given ID.
  *
  * @param string $id_or_url
  *   A DOI to lookop. May be provided with or without the "doi:" prefix. Can
@@ -36,57 +78,46 @@ function islandora_doi_get_doi_name_from_url($doi_url) {
  *   An object as provided by drupal_http_request().
  */
 function islandora_doi_perform_request($id_or_url) {
+  global $_islandora_doi_content_translators;
   // Allows for $id to pass a DOI url string or the DOI name.
   $id = islandora_doi_get_doi_name_from_url($id_or_url);
-  $openurl = variable_get('islandora_doi_openurl', 'http://www.crossref.org/openurl');
-  $openurl_pid = variable_get('islandora_doi_openurl_pid', 'user@example.com');
-  $url = url($openurl, array(
-           'query' => array(
-             'noredirect' => 'true',
-             'pid' => $openurl_pid,
-             'format' => 'unixref',
-             'id' => ((strpos($id, 'doi:') === 0) ? $id : 'doi:' . $id),
-           ),
-  ));
+  $options = array();
+  if (variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT) === TRUE) {
+    $openurl = variable_get('islandora_doi_openurl', ISLANDORA_DOI_OPENURL_DEFAULT);
+    $openurl_pid = variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT);
+    $url = url($openurl, array(
+             'query' => array(
+               'noredirect' => 'true',
+               'pid' => $openurl_pid,
+               'format' => 'unixref',
+               'id' => ((strpos($id, 'doi:') === 0) ? $id : 'doi:' . $id),
+             ),
+    ));
+  }
+  else {
+    $doiurl = variable_get('islandora_doi_doiurl', ISLANDORA_DOI_DOIURL_DEFAULT);
+    $url = url($doiurl . '/' . $id);
+    $options = array(
+      'headers' => array(
+        'Accept' => implode(', ', array_keys($_islandora_doi_content_translators)),
+      ),
+      'max_redirects' => 1,
+    );
+  }
 
-  return drupal_http_request($url);
+  return drupal_http_request($url, $options);
 }
 
 /**
  * Produce MODS from the given CrossRef XML.
  *
- * @param mixed $doi_xml
- *   XML containing the parsed response from CrossRef. Should be passed as a 
- *   DOMDocument, but also works with a SimpleXMLElement.
+ * @param DOMDocument $crossref_xml
+ *   DOMDocument containing the parsed response from CrossRef.
  *
  * @return DOMDocument|bool
  *   A DOMDocument containing the constructed MODS, or FALSE on failure.
- *
- * @throws Exception
- *   If passed a SimpleXMLElement that can't be converted to DOMDocument.
- *
- * @throws InvalidArgumentException
- *   If passed something other than DOMDocument or SimpleXMLElement.
  */
-function islandora_doi_transform_to_mods($doi_xml) {
-  // Make sure doi_xml is a DOMDocument. Otherwise show a warning and, if it
-  // is a SimpleXMLElement, convert it.
-  if ($doi_xml instanceof SimpleXMLElement) {
-    // Warning message: Converting from SimpleXMLElement.
-    watchdog('Islandora DOI', 'islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.');
-    trigger_error(t('islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.'));
-    $dom_xml = new DOMDocument();
-    if (!$dom_xml = dom_import_simplexml($doi_xml)) {
-      // Error message: Failed to convert from SimpleXMLElement.
-      throw new Exception('Failed to convert SimpleXMLElement to DOMDocument');
-    }
-    $doi_xml = $dom_xml;
-  }
-  elseif (!($doi_xml instanceof DOMDocument)) {
-    // Error message: Not supplied with a DOMDocument.
-    throw new InvalidArgumentException('islandora_doi_transform_to_mods should take a DOMDocument');
-  }
-
+function islandora_doi_crossref_translator($crossref_xml) {
   // Create MODS XML.
   $mods = new DOMDocument('1.0');
   $mods->loadXML('<mods xmlns="http://www.loc.gov/mods/v3" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink"/>');
@@ -94,7 +125,7 @@ function islandora_doi_transform_to_mods($doi_xml) {
   // @todo Implement book support.
 
   // Add metadata for journal articles.
-  foreach ($doi_xml->getElementsByTagName('journal') as $journal) {
+  foreach ($crossref_xml->getElementsByTagName('journal') as $journal) {
     $genre = $mods->createElement('genre');
     $genre->nodeValue = 'article';
     $mods->firstChild->appendChild($genre);
@@ -555,30 +586,200 @@ function islandora_doi_transform_to_mods($doi_xml) {
 }
 
 /**
+ * Validate CrossRef data.
+ *
+ * @param string $id
+ *   A DOI.
+ * @param string $data
+ *   A string containing the data returned by CrossRef for the DOI.
+ *
+ * @return bool
+ *   TRUE, if the content is valid and should be transformed to MODS, FALSE
+ *   otherwise.
+ */
+function islandora_doi_crossref_validator($id, $crossref_data) {
+  $doi = islandora_doi_get_doi_name_from_url($id);
+  $crossref_xml = simplexml_load_string($crossref_data);
+  if ($crossref_xml->doi_record->crossref->error) {
+    // This should only occur in legacy mode.
+    drupal_set_message(t("CrossREF reports the DOI '@doi' as erroneous.", array(
+        '@doi' => $doi,
+      )), 'error');
+    return FALSE;
+  }
+  // Totally don't support books so let's not attempt to make records that
+  // are actually books!
+  if (!$crossref_xml->doi_record->crossref->journal) {
+    drupal_set_message(t("Only the 'Journal' type is currently supported for DOI importing (offending DOI: '@doi').", array(
+        '@doi' => $doi,
+      )), 'error');
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * Produce MODS from the given metadata provider XML.
+ *
+ * @param mixed $doi_xml
+ *   XML containing the parsed response from the metadata provider. Should be
+ *   passed as a DOMDocument, but also works with a SimpleXMLElement.
+ * @param string $content_type
+ *   Optional parameter specifying the content type to translate (defaults to
+ *   'application/vnd.crossref.unixref+xml', i.e. CrossRef data).
+ *
+ * @return DOMDocument|bool
+ *   A DOMDocument containing the constructed MODS, or FALSE on failure.
+ *
+ * @throws Exception
+ *   If passed a SimpleXMLElement that can't be converted to DOMDocument.
+ *
+ * @throws InvalidArgumentException
+ *   If passed something other than DOMDocument or SimpleXMLElement.
+ */
+function islandora_doi_transform_to_mods($doi_xml, $content_type = 'application/vnd.crossref.unixref+xml') {
+  global $_islandora_doi_content_translators;
+  if (!array_key_exists($content_type, $_islandora_doi_content_translators)) {
+    // Warning message: Translator not yet implemented.
+    $err_msg = 'The requested translator for content \'@content_type\' has not yet been implemented. Returning FALSE...';
+    $err_msg_vars = array(
+      '@content_type' => $content_type,
+    );
+    watchdog('Islandora DOI', $err_msg, $err_msg_vars);
+    trigger_error(t($err_msg, $err_msg_vars));
+    return FALSE;
+  }
+  // Make sure doi_xml is a DOMDocument. Otherwise show a warning and, if it
+  // is a SimpleXMLElement, convert it.
+  if ($doi_xml instanceof SimpleXMLElement) {
+    // Warning message: Converting from SimpleXMLElement.
+    $err_msg = 'islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.';
+    watchdog('Islandora DOI', $err_msg);
+    trigger_error(t($err_msg));
+    $dom_xml = new DOMDocument();
+    if (!$dom_xml = dom_import_simplexml($doi_xml)) {
+      // Error message: Failed to convert from SimpleXMLElement.
+      throw new Exception('Failed to convert SimpleXMLElement to DOMDocument');
+    }
+    $doi_xml = $dom_xml;
+  }
+  elseif (!($doi_xml instanceof DOMDocument)) {
+    // Error message: Not supplied with a DOMDocument.
+    throw new InvalidArgumentException('islandora_doi_transform_to_mods should take a DOMDocument');
+  }
+
+  return $_islandora_doi_content_translators[$content_type]($doi_xml);
+}
+
+/**
+ * Get the content type and source string for the given DOI.
+ *
+ * @param string $id
+ *   A DOI.
+ *
+ * @return array|bool
+ *   A single-valued array, where the key is the content type and the value is
+ *   the source data string as returned by the metadata provider, or FALSE if
+ *   either an error occured or the source data is invalid according to the
+ *   validator.
+ */
+function islandora_doi_get_source($id) {
+  global $_islandora_doi_content_translators;
+  global $_islandora_doi_content_validators;
+  $response = islandora_doi_perform_request($id);
+  $headers = array_change_key_case($response->headers);
+  if (variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT) === TRUE) {
+    // In legacy mode, we only queried CrossRef.
+    if (!$response->data ||
+      strpos($headers['content-type'], 'text/html') !== FALSE ||
+      strpos($response->data, "Malformed DOI") !== FALSE) {
+      drupal_set_message(t('\'@doi\' does not seem to be a valid CrossREF DOI.', array(
+        '@doi' => islandora_doi_get_doi_name_from_url($id),
+      )), 'error');
+      return FALSE;
+    }
+    $content_type = 'application/vnd.crossref.unixref+xml';
+  }
+  else {
+    // In non-legacy mode, the response may come from any metadata provider
+    // or @link https://doi.org doi.org @endlink itself.
+    if (!$response->data ||
+      !isset($response->code) || $response->code != 200 || isset($response->error) ||
+      !array_key_exists($headers['content-type'], $_islandora_doi_content_translators)) {
+      $err_406_msg = 'It seems that the metadata provider for \'@doi\' has no content we can handle.';
+      if (isset($response->error)) {
+        if (isset($response->code) && $response->code == 406) {
+          // We should always find ourselves here when the DOI exists but we
+          // requested content types the metadata provider does not support.
+          // Unfortunately, not all providers behave as expected, which
+          // explains the slightly more convoluted construction below.
+          $err_msg = $err_406_msg;
+        }
+        elseif (isset($response->code) && $response->code == 404) {
+          // We would expect this to be the response for invalid DOIs only,
+          // but this is not the case...
+          $err_msg = '\'@doi\' does not appear to be a valid DOI';
+          // We know that, e.g., DataCite will return 404 if the first content
+          // type in the Accept header differs from
+          // 'application/vnd.datacite.datacite+xml'. It seems that truly invalid
+          // DOIs get redirected to https://www.doi.org when https://doi.org is
+          // queried.
+          if (isset($response->redirect_url) &&
+            preg_match('/^https?:\/\/www.doi.org/', $response->redirect_url) !== 1) {
+            $err_msg .= ' (or the metadata provider for this DOI has no content we can handle)';
+          }
+          $err_msg .= '.';
+        }
+      }
+      elseif (isset($response->code) && $response->code >= 300 && $response->code <= 308 &&
+        isset($response->redirect_url)) {
+        // The metadata provider tries to redirect us, in all likelyhood to
+        // the publisher's website. We treat this the same as 406 above.
+        $err_msg = $err_406_msg;
+      }
+      if (isset($err_msg)) {
+        drupal_set_message(t($err_msg, array(
+          '@doi' => islandora_doi_get_doi_name_from_url($id),
+        )), 'error');
+      }
+      return FALSE;
+    }
+    $content_type = $headers['content-type'];
+  }
+  if (array_key_exists($content_type, $_islandora_doi_content_validators) &&
+    $_islandora_doi_content_validators[$content_type]($id, $response->data) !== TRUE) {
+    // No error message here, since the validator should take care of that.
+    return FALSE;
+  }
+
+  return array($content_type => $response->data);
+}
+
+/**
  * Get MODS for the given DOI.
  *
  * @param string $id
  *   A DOI.
  *
- * @return SimpleXMLElement|bool
- *   A SimpleXMLElement containing a MODS document, or FALSE if either an error
+ * @return DOMDocument|bool
+ *   A DOMDocument containing a MODS document, or FALSE if either an error
  *   occured or nothing could be transformed.
  */
 function islandora_doi_get_mods($id) {
-  $response = islandora_doi_perform_request($id);
-  $headers = array_change_key_case($response->headers);
-  if ($response->data &&
-    strpos($headers['content-type'], 'text/html') === FALSE &&
-    strpos($response->data, "Malformed DOI") === FALSE) {
-    $crossref_xml = new DOMDocument('1.0');
-    if (!$crossref_xml->loadXML($response->data)) {
-      return FALSE;
-    }
-    else {
-      return islandora_doi_transform_to_mods($crossref_xml);
-    }
-  }
-  else {
+  global $_islandora_doi_content_translators;
+  $source_array = islandora_doi_get_source($id);
+  if ($source_array === FALSE) {
     return FALSE;
   }
+  $content_types = array_keys($source_array);
+  // There should be only one, but just take the first to be sure.
+  $content_type = array_shift($content_types);
+  $source_string = $source_array[$content_type];
+  $xml = new DOMDocument('1.0');
+  if (!$xml->loadXML($source_string)) {
+    return FALSE;
+  }
+
+  return islandora_doi_transform_to_mods($xml, $content_type);
 }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -6,46 +6,66 @@
  */
 
 /**
- * Global variable containing an array, where the keys are acceptable content
- * types and their values are handler function names for those types. The
- * functions are supposed to translate the returned XML data into MODS.
+ * Check if we should use legacy mode.
  *
- * Note: At the time of writing, @link https//doi.org doi.org @endlink was able
- * to perform the content negociation as explained on
- * @link https://www.crosscite.org/docs.html crosscite.org. @endlink Since we
- * are using the array keys to construct the Accept header of the HTTP request,
- * their order plays a role. So far, the requests alone were tested
- * simultaneously for @link https://www.crossref.org CrossRef, @endlink
- * @link https://datacite.org DataCite @endlink and
- * @link https://www.medra.org mEDRA. @endlink (content types
- * 'application/vnd.crossref.unixref+xml',
- * 'application/vnd.datacite.datacite+xml' and
- * 'application/vnd.medra.onixdoi+xml', respectively). It was noticed that:
- * - qvalues are not supported (see
- *   https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
- * - DataCite will only deliver if its content type comes first.
- * You may want to take into account those findings when extending this
- * module to support other metadata providers.
+ * @return bool
+ *   TRUE, if we should use legacy mode to retrieve the metadata, FALSE
+ *   otherwise.
  */
-global $_islandora_doi_content_translators;
-$_islandora_doi_content_translators = array(
-  'application/vnd.crossref.unixref+xml' => 'islandora_doi_crossref_translator',
-);
+function islandora_doi_use_legacy_mode() {
+  return (variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT) === TRUE);
+}
 
 /**
- * Global variable containing an array, where the keys are acceptable content
- * types and their values are validator function names for those types. The
- * functions are supposed to validate the string data returned by the metadata
- * provider, returning TRUE if the content is valid, FALSE otherwise.
- *
- * To improve error messages, the function's first argument should be the DOI
- * of the item to be ingested. For content types that need no validation, just
- * omit their keys here.
+ * Implements hook_islandora_doi_content_type_info().
  */
-global $_islandora_doi_content_validators;
-$_islandora_doi_content_validators = array(
-  'application/vnd.crossref.unixref+xml' => 'islandora_doi_crossref_validator',
-);
+function islandora_doi_islandora_doi_content_type_info() {
+  $info = array();
+  $crossref_type = 'application/vnd.crossref.unixref+xml';
+  $crossref_info = array(
+    'translator' => 'islandora_doi_crossref_translator',
+    'validator' => 'islandora_doi_crossref_validator',
+  );
+  $info[$crossref_type] = $crossref_info;
+  return $info;
+}
+
+/**
+ * Wrap a module_invoke_all() call.
+ */
+function islandora_doi_get_content_type_info() {
+  $info = module_invoke_all('islandora_doi_content_type_info');
+  drupal_alter('islandora_doi_content_type_info', $info);
+  return $info;
+}
+
+/**
+ * Helper function to sort content type info.
+ */
+function _islandora_doi_info_compare($a, $b) {
+  if (!isset($a['weight'])) {
+    $a['weight'] = 0;
+  }
+  if (!isset($b['weight'])) {
+    $b['weight'] = 0;
+  }
+  if ($a['weight'] == $b['weight']) {
+    return 0;
+  }
+  return ($a['weight'] < $b['weight']) ? -1 : 1;
+}
+
+/**
+ * Get HTTP Access header string.
+ *
+ * @return string
+ *   The string to set as HTTP Access header.
+ */
+function islandora_doi_get_http_access() {
+  $info = islandora_doi_get_content_type_info();
+  uasort($info, '_islandora_doi_info_compare');
+  return implode(', ', array_keys($info));
+}
 
 /**
  * Get the DOI name for the given url.
@@ -78,11 +98,10 @@ function islandora_doi_get_doi_name_from_url($doi_url) {
  *   An object as provided by drupal_http_request().
  */
 function islandora_doi_perform_request($id_or_url) {
-  global $_islandora_doi_content_translators;
   // Allows for $id to pass a DOI url string or the DOI name.
   $id = islandora_doi_get_doi_name_from_url($id_or_url);
   $options = array();
-  if (variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT) === TRUE) {
+  if (islandora_doi_use_legacy_mode()) {
     $openurl = variable_get('islandora_doi_openurl', ISLANDORA_DOI_OPENURL_DEFAULT);
     $openurl_pid = variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT);
     $url = url($openurl, array(
@@ -96,10 +115,13 @@ function islandora_doi_perform_request($id_or_url) {
   }
   else {
     $doiurl = variable_get('islandora_doi_doiurl', ISLANDORA_DOI_DOIURL_DEFAULT);
+    if (strpos($id, 'doi:') === 0) {
+      $id = substr($id, 4);
+    }
     $url = url($doiurl . '/' . $id);
     $options = array(
       'headers' => array(
-        'Accept' => implode(', ', array_keys($_islandora_doi_content_translators)),
+        'Accept' => islandora_doi_get_http_access(),
       ),
       'max_redirects' => 1,
     );
@@ -109,15 +131,14 @@ function islandora_doi_perform_request($id_or_url) {
 }
 
 /**
- * Produce MODS from the given CrossRef XML.
- *
- * @param DOMDocument $crossref_xml
- *   DOMDocument containing the parsed response from CrossRef.
- *
- * @return DOMDocument|bool
- *   A DOMDocument containing the constructed MODS, or FALSE on failure.
+ * Implements callback_islandora_doi_translator() for CrossRef data.
  */
-function islandora_doi_crossref_translator($crossref_xml) {
+function islandora_doi_crossref_translator($crossref_data) {
+  // Parse the source into a DOMDocument.
+  $crossref_xml = new DOMDocument("1.0");
+  if (!$crossref_xml->loadXML($crossref_data)) {
+    return FALSE;
+  }
   // Create MODS XML.
   $mods = new DOMDocument('1.0');
   $mods->loadXML('<mods xmlns="http://www.loc.gov/mods/v3" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink"/>');
@@ -586,16 +607,7 @@ function islandora_doi_crossref_translator($crossref_xml) {
 }
 
 /**
- * Validate CrossRef data.
- *
- * @param string $id
- *   A DOI.
- * @param string $crossref_data
- *   A string containing the data returned by CrossRef for the DOI.
- *
- * @return bool
- *   TRUE, if the content is valid and should be transformed to MODS, FALSE
- *   otherwise.
+ * Implements callback_islandora_doi_validator() for CrossRef data.
  */
 function islandora_doi_crossref_validator($id, $crossref_data) {
   $doi = islandora_doi_get_doi_name_from_url($id);
@@ -620,7 +632,44 @@ function islandora_doi_crossref_validator($id, $crossref_data) {
 }
 
 /**
+ * Produce MODS from the given metadata provider response data.
+ *
+ * @param string $data
+ *   The data response of the metadata provider.
+ * @param string $content_type
+ *   The content type of the given data.
+ *
+ * @return DOMDocument|bool
+ *   A DOMDocument containing the constructed MDOS, or FALSE on failure.
+ */
+function islandora_doi_translate($data, $content_type) {
+  $info = islandora_doi_get_content_type_info();
+  if (!array_key_exists($content_type, $info)) {
+    // Warning message: Translator not yet implemented.
+    watchdog('Islandora DOI', "The requested translator for content '@content_type' has not yet been implemented. Returning FALSE...", array(
+      '@content_type' => $content_type,
+    ));
+    trigger_error(t("The requested translator for content '@content_type' has not yet been implemented. Returning FALSE...", array(
+      '@content_type' => check_plain($content_type),
+    )));
+    return FALSE;
+  }
+  if (!isset($info[$content_type]['translator'])) {
+    return FALSE;
+  }
+  if (isset($info[$content_type]['file'])) {
+    require_once DRUPAL_ROOT . '/' . $info[$content_type]['file'];
+  }
+  return $info[$content_type]['translator']($data);
+}
+
+/**
  * Produce MODS from the given metadata provider XML.
+ *
+ * @deprecated As of release 7.x-1.11, this function remains only for backwards
+ *   compatibilty. New code should use islandora_doi_translate() instead, which
+ *   takes unparsed data to convert. Update your code, since this function
+ *   might be removed.
  *
  * @param mixed $doi_xml
  *   XML containing the parsed response from the metadata provider. Should be
@@ -639,28 +688,22 @@ function islandora_doi_crossref_validator($id, $crossref_data) {
  *   If passed something other than DOMDocument or SimpleXMLElement.
  */
 function islandora_doi_transform_to_mods($doi_xml, $content_type = 'application/vnd.crossref.unixref+xml') {
-  global $_islandora_doi_content_translators;
-  if (!array_key_exists($content_type, $_islandora_doi_content_translators)) {
-    // Warning message: Translator not yet implemented.
-    watchdog('Islandora DOI', "The requested translator for content '@content_type' has not yet been implemented. Returning FALSE...", array(
-      '@content_type' => $content_type,
-    ));
-    trigger_error(t("The requested translator for content '@content_type' has not yet been implemented. Returning FALSE...", array(
-      '@content_type' => check_plain($content_type),
-    )));
-    return FALSE;
-  }
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $deprecated_message = islandora_deprecated('7.x-1.11', t('Use @newfunction() instead.', array('@newfunction' => 'islandora_doi_translate')));
+  trigger_error(filter_xss($deprecated_message), E_USER_DEPRECATED);
   // Make sure doi_xml is a DOMDocument. Otherwise show a warning and, if it
   // is a SimpleXMLElement, convert it.
   if ($doi_xml instanceof SimpleXMLElement) {
     // Warning message: Converting from SimpleXMLElement.
     watchdog('Islandora DOI', 'islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.');
     trigger_error(t('islandora_doi_transform_to_mods should be passed a DOMDocument but received a SimpleXMLElement. Attempting to convert the SimpleXMLElement to a DOMDocument. Code should be updated to call islandora_doi_transform_to_mods with a DOMDocument instead.'));
-    $dom_xml = new DOMDocument();
-    if (!$dom_xml = dom_import_simplexml($doi_xml)) {
+    $dom_xml = new DOMDocument('1.0');
+    if (!$dom_xmle = dom_import_simplexml($doi_xml)) {
       // Error message: Failed to convert from SimpleXMLElement.
       throw new Exception('Failed to convert SimpleXMLElement to DOMDocument');
     }
+    $dom_xmle = $dom_xml->importNode($dom_xmle, TRUE);
+    $dom_xml->appendChild($dom_xmle);
     $doi_xml = $dom_xml;
   }
   elseif (!($doi_xml instanceof DOMDocument)) {
@@ -668,7 +711,7 @@ function islandora_doi_transform_to_mods($doi_xml, $content_type = 'application/
     throw new InvalidArgumentException('islandora_doi_transform_to_mods should take a DOMDocument');
   }
 
-  return $_islandora_doi_content_translators[$content_type]($doi_xml);
+  return islandora_doi_translate($doi_xml->saveXML(), $content_type);
 }
 
 /**
@@ -678,17 +721,16 @@ function islandora_doi_transform_to_mods($doi_xml, $content_type = 'application/
  *   A DOI.
  *
  * @return array|bool
- *   A single-valued array, where the key is the content type and the value is
- *   the source data string as returned by the metadata provider, or FALSE if
- *   either an error occured or the source data is invalid according to the
- *   validator.
+ *   A bi-valued array, where the first value is the source data string as
+ *   returned by the metadata provider and the second value is the content
+ *   type, or FALSE if either an error occured or the source data is invalid
+ *   according to the validator.
  */
 function islandora_doi_get_source($id) {
-  global $_islandora_doi_content_translators;
-  global $_islandora_doi_content_validators;
+  $info = islandora_doi_get_content_type_info();
   $response = islandora_doi_perform_request($id);
   $headers = array_change_key_case($response->headers);
-  if (variable_get('islandora_doi_use_legacy_mode', variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT) !== ISLANDORA_DOI_OPENURL_PID_DEFAULT) === TRUE) {
+  if (islandora_doi_use_legacy_mode()) {
     // In legacy mode, we only queried CrossRef.
     if (!$response->data ||
       strpos($headers['content-type'], 'text/html') !== FALSE ||
@@ -705,7 +747,7 @@ function islandora_doi_get_source($id) {
     // or @link https://doi.org doi.org @endlink itself.
     if (!$response->data ||
       !isset($response->code) || $response->code != 200 || isset($response->error) ||
-      !array_key_exists($headers['content-type'], $_islandora_doi_content_translators)) {
+      !array_key_exists($headers['content-type'], $info)) {
       if (isset($response->error)) {
         if (isset($response->code) && $response->code == 406) {
           // We should always find ourselves here when the DOI exists but we
@@ -749,13 +791,17 @@ function islandora_doi_get_source($id) {
     }
     $content_type = $headers['content-type'];
   }
-  if (array_key_exists($content_type, $_islandora_doi_content_validators) &&
-    $_islandora_doi_content_validators[$content_type]($id, $response->data) !== TRUE) {
-    // No error message here, since the validator should take care of that.
-    return FALSE;
+  if (array_key_exists($content_type, $info) && isset($info[$content_type]['validator'])) {
+    if (isset($info[$content_type]['file'])) {
+      require_once DRUPAL_ROOT . '/' . $info[$content_type]['file'];
+    }
+    if ($info[$content_type]['validator']($id, $response->data) !== TRUE) {
+      // No error message here, since the validator should take care of that.
+      return FALSE;
+    }
   }
 
-  return array($content_type => $response->data);
+  return array($response->data, $content_type);
 }
 
 /**
@@ -769,19 +815,11 @@ function islandora_doi_get_source($id) {
  *   occured or nothing could be transformed.
  */
 function islandora_doi_get_mods($id) {
-  global $_islandora_doi_content_translators;
   $source_array = islandora_doi_get_source($id);
   if ($source_array === FALSE) {
     return FALSE;
   }
-  $content_types = array_keys($source_array);
-  // There should be only one, but just take the first to be sure.
-  $content_type = array_shift($content_types);
-  $source_string = $source_array[$content_type];
-  $xml = new DOMDocument('1.0');
-  if (!$xml->loadXML($source_string)) {
-    return FALSE;
-  }
+  list($source_string, $content_type) = $source_array;
 
-  return islandora_doi_transform_to_mods($xml, $content_type);
+  return islandora_doi_translate($source_string, $content_type);
 }

--- a/modules/doi/islandora_doi.api.php
+++ b/modules/doi/islandora_doi.api.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @file
+ * Document interfaces/hooks exposed by this module.
+ */
+
+/**
+ * Gather info for content negotiation.
+ *
+ * @return array
+ *   An associative array mapping MIME-types to associative arrays containing:
+ *    - translator: A callable implementing callback_islandora_doi_translator().
+ *    - validator: A callable implementing callback_islandora_doi_validator().
+ *    - weight: Integer to control order in HTTP Accept header (lower values
+ *      are listed earlier in the Accept header; assumes 0 if unspecified;
+ *      equal weights will be sorted unpredictably).
+ *    - file: Optional location of file containing translator/validator
+ *      functions (path relative to DRUPAL_ROOT).
+ *
+ * Note: At the time of writing, @link https//doi.org doi.org @endlink was
+ * able to perform the content negotiation as explained on
+ * @link https://www.crosscite.org/docs.html crosscite.org. @endlink Since we
+ * are using the array keys to construct the Accept header of the HTTP
+ * request, their order plays a role. So far, the requests alone were tested
+ * simultaneously for @link https://www.crossref.org CrossRef, @endlink
+ * @link https://datacite.org DataCite @endlink and
+ * @link https://www.medra.org mEDRA. @endlink (content types
+ * 'application/vnd.crossref.unixref+xml',
+ * 'application/vnd.datacite.datacite+xml' and
+ * 'application/vnd.medra.onixdoi+xml', respectively). It was noticed that:
+ * - qvalues are not supported (see
+ *   https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
+ * - DataCite will only deliver if its content type comes first.
+ * You may want to take into account those findings when extending this
+ * module to support other metadata providers and set the weight accordingly.
+ */
+function hook_islandora_doi_content_type_info() {
+  return array('text/xml' => array(
+    'translator' => 'my_xml_translator',
+    'validator' => 'my_xml_validator',
+    'weight' => -13,
+    'file' => 'path/to/module/includefile.inc',
+  ));
+}
+
+/**
+ * Allow other modules to alter info for content negotiation.
+ *
+ * @param array $info
+ *   The associative array of variables being passed to islandora_doi.
+ */
+function hook_islandora_doi_content_type_info_alter(array &$info) {
+  if (isset($info['text/xml'])) {
+    unset($info['text/xml']);
+  }
+}
+
+/**
+ * Translate response to MODS, contained in a DOMDocument.
+ *
+ * @param string $data
+ *   The response to be transformed.
+ *
+ * @return DOMDocument|bool
+ *   The translated document as a DOMDocument; otherwise, boolean FALSE on
+ *   failure.
+ */
+function callback_islandora_doi_translator(string $data) {
+  // For an example, @see islandora_doi_crossref_translator().
+}
+
+/**
+ * Validate response.
+ *
+ * @param string $id
+ *   The DOI the response is supposed to represent.
+ * @param string $data
+ *   The response to validate.
+ *
+ * @return bool
+ *   TRUE if the response appears to be valid; otherwise, FALSE.
+ */
+function callback_islandora_doi_validator(string $id, string $data) {
+  // For an example, @see islandora_doi_crossref_validator().
+}

--- a/modules/doi/islandora_doi.module
+++ b/modules/doi/islandora_doi.module
@@ -5,9 +5,9 @@
  * Support code to harvest records, given DOIs.
  */
 
-define('ISLANDORA_DOI_OPENURL_DEFAULT', 'http://www.crossref.org/openurl');
-define('ISLANDORA_DOI_OPENURL_PID_DEFAULT', 'user@example.com');
-define('ISLANDORA_DOI_DOIURL_DEFAULT', 'https://doi.org');
+const ISLANDORA_DOI_OPENURL_DEFAULT = 'http://www.crossref.org/openurl';
+const ISLANDORA_DOI_OPENURL_PID_DEFAULT = 'user@example.com';
+const ISLANDORA_DOI_DOIURL_DEFAULT = 'https://doi.org';
 
 /**
  * Implements hook_menu().

--- a/modules/doi/islandora_doi.module
+++ b/modules/doi/islandora_doi.module
@@ -5,6 +5,9 @@
  * Support code to harvest records, given DOIs.
  */
 
+define('ISLANDORA_DOI_OPENURL_DEFAULT', 'http://www.crossref.org/openurl');
+define('ISLANDORA_DOI_OPENURL_PID_DEFAULT', 'user@example.com');
+define('ISLANDORA_DOI_DOIURL_DEFAULT', 'https://doi.org');
 
 /**
  * Implements hook_menu().

--- a/modules/doi/modules/doi_importer/README.md
+++ b/modules/doi/modules/doi_importer/README.md
@@ -19,7 +19,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 ## Configuration
 
-Set the value for `OpenURL PID` at `admin/islandora/scholar/doi_importer` as CrossRef does not allow guest searching, or just use the new content negociation based metadata retrieval.
+Set the value for "OpenURL PID" at `admin/islandora/scholar/doi_importer` as CrossRef does not allow guest searching, or just use the new content negotiation based metadata retrieval.
 
 ## Troubleshooting/Issues
 

--- a/modules/doi/modules/doi_importer/README.md
+++ b/modules/doi/modules/doi_importer/README.md
@@ -19,7 +19,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 ## Configuration
 
-Set the value for `OpenURL PID` at `admin/islandora/scholar/doi_importer` as CrossRef does not allow guest searching.
+Set the value for `OpenURL PID` at `admin/islandora/scholar/doi_importer` as CrossRef does not allow guest searching, or just use the new content negociation based metadata retrieval.
 
 ## Troubleshooting/Issues
 

--- a/modules/doi/modules/doi_importer/includes/importer.inc
+++ b/modules/doi/modules/doi_importer/includes/importer.inc
@@ -24,9 +24,10 @@ class DOIImporter extends IslandoraBatchImporter {
    *
    * @see IslandoraBatchImporter::getForm()
    */
-  public static function getForm(array & $form_state) {
+  public static function getForm(array &$form_state) {
+    form_load_include($form_state, 'inc', 'islandora_doi', 'includes/utilities');
     $openurl_pid = variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT);
-    $legacy_mode = variable_get('islandora_doi_use_legacy_mode', $openurl_pid !== ISLANDORA_DOI_OPENURL_PID_DEFAULT);
+    $legacy_mode = islandora_doi_use_legacy_mode();
     if ($legacy_mode && $openurl_pid == ISLANDORA_DOI_OPENURL_PID_DEFAULT) {
       drupal_set_message(t('OpenURL PID email address has not been configured, please enter a valid email address in the <a href="@doi-admin-page">Scholar DOI configuration form</a> or use the non-legacy mode.', array('@doi-admin-page' => '/admin/islandora/solution_pack_config/scholar/islandora_doi')), 'error');
     }
@@ -114,7 +115,7 @@ class DOIImportObject extends IslandoraImportObject {
   /**
    * Generated MODS Document.
    *
-   * @var SimpleXMLElement
+   * @var string
    */
   protected $mods;
 
@@ -138,10 +139,7 @@ class DOIImportObject extends IslandoraImportObject {
     if ($source_array === FALSE) {
       return FALSE;
     }
-    $content_types = array_keys($source_array);
-    // There should be only one, but just take the first to be sure.
-    $content_type = array_shift($content_types);
-    $source_string = $source_array[$content_type];
+    list($source_string, $content_type) = $source_array;
     $toreturn = new self($source_string);
     $toreturn->sourceContentType = $content_type;
     return $toreturn;
@@ -156,9 +154,14 @@ class DOIImportObject extends IslandoraImportObject {
     if ($this->mods === NULL) {
       // @todo Implement book support.
       module_load_include('inc', 'islandora_doi', 'includes/utilities');
-      $doi_xml = new DOMDocument('1.0');
-      $doi_xml->loadXML($this->source);
-      $this->mods = islandora_doi_transform_to_mods($doi_xml, $this->sourceContentType)->saveXML();
+      $content_type = $this->sourceContentType;
+      // If no content type is set, we assume that the object was there before
+      // the module got updated to retrieve data via content negotiation, i.e.
+      // the object source contains CrossRef metadata.
+      if (!isset($content_type)) {
+        $content_type = 'application/vnd.crossref.unixref+xml';
+      }
+      $this->mods = islandora_doi_translate($this->source, $content_type)->saveXML();
     }
 
     return $this->mods;

--- a/modules/doi/modules/doi_importer/includes/importer.inc
+++ b/modules/doi/modules/doi_importer/includes/importer.inc
@@ -123,7 +123,7 @@ class DOIImportObject extends IslandoraImportObject {
    *
    * @var string
    */
-  protected $source_content_type;
+  protected $sourceContentType;
 
   /**
    * Get an item from the source.
@@ -143,7 +143,7 @@ class DOIImportObject extends IslandoraImportObject {
     $content_type = array_shift($content_types);
     $source_string = $source_array[$content_type];
     $toreturn = new self($source_string);
-    $toreturn->source_content_type = $content_type;
+    $toreturn->sourceContentType = $content_type;
     return $toreturn;
   }
 
@@ -158,7 +158,7 @@ class DOIImportObject extends IslandoraImportObject {
       module_load_include('inc', 'islandora_doi', 'includes/utilities');
       $doi_xml = new DOMDocument('1.0');
       $doi_xml->loadXML($this->source);
-      $this->mods = islandora_doi_transform_to_mods($doi_xml, $this->source_content_type)->saveXML();
+      $this->mods = islandora_doi_transform_to_mods($doi_xml, $this->sourceContentType)->saveXML();
     }
 
     return $this->mods;

--- a/modules/doi/modules/doi_importer/includes/importer.inc
+++ b/modules/doi/modules/doi_importer/includes/importer.inc
@@ -25,16 +25,17 @@ class DOIImporter extends IslandoraBatchImporter {
    * @see IslandoraBatchImporter::getForm()
    */
   public static function getForm(array & $form_state) {
-    $openurl_pid = variable_get('islandora_doi_openurl_pid', 'user@example.com');
-    if ($openurl_pid == 'user@example.com') {
-      drupal_set_message(t('OpenURL PID email address has not been configured, please enter a valid email address in the <a href="@doi-admin-page">Scholar DOI configuration form</a>.', array('@doi-admin-page' => '/admin/islandora/solution_pack_config/scholar/islandora_doi')), 'error');
+    $openurl_pid = variable_get('islandora_doi_openurl_pid', ISLANDORA_DOI_OPENURL_PID_DEFAULT);
+    $legacy_mode = variable_get('islandora_doi_use_legacy_mode', $openurl_pid !== ISLANDORA_DOI_OPENURL_PID_DEFAULT);
+    if ($legacy_mode && $openurl_pid == ISLANDORA_DOI_OPENURL_PID_DEFAULT) {
+      drupal_set_message(t('OpenURL PID email address has not been configured, please enter a valid email address in the <a href="@doi-admin-page">Scholar DOI configuration form</a> or use the non-legacy mode.', array('@doi-admin-page' => '/admin/islandora/solution_pack_config/scholar/islandora_doi')), 'error');
     }
     else {
       return array(
         'fs' => array(
           '#type' => 'fieldset',
           '#title' => t('DOI Batch Journal Importer'),
-          '#description' => t('Provide either a list of Digital Object Identifiers in a file, or enter DOIs in the textarea below. In either case, the DOIs in the list should be separated by either whitespace or commas (or some combination thereof). NOTE: Presently, only journal (articles) are supported.'),
+          '#description' => t('Provide either a list of Digital Object Identifiers in a file, or enter DOIs in the textarea below. In either case, the DOIs in the list should be separated by either whitespace or commas (or some combination thereof). NOTE: Presently, only journal (articles) from CrossREF are supported.'),
           'file' => array(
             '#type' => 'managed_file',
             '#title' => t('File of DOIs'),
@@ -118,6 +119,13 @@ class DOIImportObject extends IslandoraImportObject {
   protected $mods;
 
   /**
+   * Source content type.
+   *
+   * @var string
+   */
+  protected $source_content_type;
+
+  /**
    * Get an item from the source.
    *
    * @see IslandoraImportObject::getOne()
@@ -126,29 +134,17 @@ class DOIImportObject extends IslandoraImportObject {
     $id = array_shift($ids);
 
     module_load_include('inc', 'islandora_doi', 'includes/utilities');
-    $response = islandora_doi_perform_request($id);
-    $headers = array_change_key_case($response->headers);
-    if ($response->data &&
-      strpos($headers['content-type'], 'text/html') === FALSE &&
-      strpos($response->data, "Malformed DOI") === FALSE) {
-
-      $crossref_xml = simplexml_load_string($response->data);
-      // Totally don't support books so let's not attempt to make records that
-      // are actually books!
-      if ($crossref_xml->doi_record->crossref->error) {
-        return FALSE;
-      }
-      elseif (!$crossref_xml->doi_record->crossref->journal) {
-        drupal_set_message(t("Only the 'Journal' type is currently supported for DOI importing."), 'error');
-        return FALSE;
-      }
-      else {
-        return new self($response->data);
-      }
-    }
-    else {
+    $source_array = islandora_doi_get_source($id);
+    if ($source_array === FALSE) {
       return FALSE;
     }
+    $content_types = array_keys($source_array);
+    // There should be only one, but just take the first to be sure.
+    $content_type = array_shift($content_types);
+    $source_string = $source_array[$content_type];
+    $toreturn = new self($source_string);
+    $toreturn->source_content_type = $content_type;
+    return $toreturn;
   }
 
   /**
@@ -162,7 +158,7 @@ class DOIImportObject extends IslandoraImportObject {
       module_load_include('inc', 'islandora_doi', 'includes/utilities');
       $doi_xml = new DOMDocument('1.0');
       $doi_xml->loadXML($this->source);
-      $this->mods = islandora_doi_transform_to_mods($doi_xml)->saveXML();
+      $this->mods = islandora_doi_transform_to_mods($doi_xml, $this->source_content_type)->saveXML();
     }
 
     return $this->mods;

--- a/modules/doi/modules/doi_populator/includes/populate.inc
+++ b/modules/doi/modules/doi_populator/includes/populate.inc
@@ -15,7 +15,7 @@ function doi_populator_validate_id($element, &$form_state, $form) {
   module_load_include('inc', 'islandora_doi', 'includes/utilities');
   $mods = islandora_doi_get_mods($element['#value']);
   if ($mods === FALSE) {
-    form_error($element, t('"@value" does not appear to be a valid DOI.', array(
+    form_error($element, t('"@value" does not appear to be a DOI we can handle.', array(
       '@value' => $element['#value'],
     )));
   }


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2172

# What does this Pull Request do?

Currently, [islandora_doi](https://github.com/Islandora/islandora_scholar/tree/7.x/modules/doi) uses [Crossref](https://www.crossref.org)'s openurl to retrieve metadata. This requires users to set up an account with Crossref.

Instead, islandora_doi can take advantage of [content negociation](https://www.crosscite.org/docs.html) and retrieve the metadata directly by querying https://doi.org. Not only does this method work without prior account creation, it also has the benefit of working with other metadata providers (e.g. [DataCite](https://datacite.org), [mEDRA](https://www.medra.org), etc...). This makes islandora_doi fit for future extensions.

This pull request adds this possibility, along with improving error messages.

# What's new?

* Introduce a new mode for retrieving metadata featuring:
   * Use content negociation rather than openurl
   * No prior account creation required
   * Prepare for extending to metadata providers other than Crossref
      (e.g. DataCite, mEDRA)
* Streamline error handling:
   * Handle errors exclusively in modules/doi/include/utilities.inc in order to
      obtain same messages regardless of ingest method (populator/importer)
   * Especially in the new non-legacy mode, failures to ingest should now give
      more useful messages (wrong type, wrong metadata provider, etc...)

The changes should be pretty non-intrusive. In particular, all existing
functions have been preserved (no API change for those who created their own
extensions). Also, users who already have their account set up with Crossref
will default to keep querying in legacy mode. Only the improvements in error
handling should be visible. New users will default to querying in the new mode.
The querying behaviour can be changed at all times on the configuration page
/admin/islandora/solution_pack_config/scholar/islandora_doi.


# How should this be tested?

As always, never test in a production environment!

Steps:
* Test importer & populator on different DOIs (including DOIs of metadata providers others than Crossref, as well as other document types such as books)
* Merge this PR and re-test. Everything but the error messages should be the same (the latter being a bit more useful)
* Go to /admin/islandora/solution_pack_config/scholar/islandora_doi and de-select legacy mode
* Re-test and see better error messages
* Delete the variable 'islandora_doi_openurl_pid' (or set the PID to the default "user@example.com") and re-test: in non-legacy mode the metadata is still retrievable

# Additional Notes:

* Does this change require documentation to be updated? **no**
* Does this change add any new dependencies? **no**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? **no**
* Could this change impact execution of existing code? **no**

# Interested parties
@bryjbrown @DonRichards @Islandora/7-x-1-x-committers
