### PR TITLE
Updates thesis forms: s/Degree grantor/Degree granting institution/

### DIFF
--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -478,7 +478,7 @@
           <multiple>FALSE</multiple>
           <required>FALSE</required>
           <resizable>FALSE</resizable>
-          <title>Degree Granter</title>
+          <title>Degree Granting Institution</title>
           <tree>TRUE</tree>
         </properties>
         <children>
@@ -501,10 +501,10 @@
                   <schema/>
                   <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree grantor&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
+                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree granting institution&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
                 </create>
                 <read>
-                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/..</path>
+                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/.. |  mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree granting institution']/..</path>
                   <context>parent</context>
                 </read>
                 <update>NULL</update>

--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -501,13 +501,16 @@
                   <schema/>
                   <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree granting institution&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
+                  <value>&lt;name type='corporate' authority='lcnaf'&gt;%value%&lt;/name&gt;</value>
                 </create>
                 <read>
                   <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/.. |  mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree granting institution']/..</path>
                   <context>parent</context>
                 </read>
-                <update>NULL</update>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
                 <delete>
                   <path>self::node()</path>
                   <context>self</context>
@@ -515,6 +518,42 @@
               </actions>
             </properties>
             <children>
+              <element name="role-roleterm">
+                <properties>
+                  <type>hidden</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <description>A hidden field for the role "Degree granting institution" which will update instances of "Degree grantor".  The value 'Degree granting institution' is hard-coded under Advanced Form Controls. </description>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <tree>TRUE</tree>
+                  <value>Degree granting institution</value>
+                  <actions>
+                    <create>
+                      <path>self::node()</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>xml</type>
+                      <prefix>NULL</prefix>
+                      <value>&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;%value%&lt;/roleTerm&gt;&lt;/role&gt;</value>
+                    </create>
+                    <read>
+                      <path>mods:role[mods:roleTerm = 'Degree grantor'] | mods:role[mods:roleTerm = 'Degree granting institution']</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>mods:role/mods:roleTerm</path>
+                      <context>parent</context>
+                    </update>
+                    <delete>NULL</delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
               <element name="institution">
                 <properties>
                   <type>textfield</type>

--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -736,7 +736,7 @@
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <description>The year this book was issued.</description>
+              <description>The year this thesis was issued.</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
               <multiple>FALSE</multiple>

--- a/xml/thesis_form_ISLANDORA1350.xml
+++ b/xml/thesis_form_ISLANDORA1350.xml
@@ -466,13 +466,16 @@
                   <schema/>
                   <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree granting institution&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
+                  <value>&lt;name type='corporate' authority='lcnaf'&gt;%value%&lt;/name&gt;</value>
                 </create>
                 <read>
                   <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/.. |  mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree granting institution']/..</path>
                   <context>parent</context>
                 </read>
-                <update>NULL</update>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
                 <delete>
                   <path>self::node()</path>
                   <context>self</context>
@@ -480,6 +483,42 @@
               </actions>
             </properties>
             <children>
+              <element name="role-roleterm">
+                <properties>
+                  <type>hidden</type>
+                  <access>TRUE</access>
+                  <collapsed>FALSE</collapsed>
+                  <collapsible>FALSE</collapsible>
+                  <description>A hidden field for the role "Degree granting institution" which will update instances of "Degree grantor".  The value 'Degree granting institution' is hard-coded under Advanced Form Controls. </description>
+                  <disabled>FALSE</disabled>
+                  <executes_submit_callback>FALSE</executes_submit_callback>
+                  <multiple>FALSE</multiple>
+                  <required>FALSE</required>
+                  <resizable>FALSE</resizable>
+                  <tree>TRUE</tree>
+                  <value>Degree granting institution</value>
+                  <actions>
+                    <create>
+                      <path>self::node()</path>
+                      <context>parent</context>
+                      <schema/>
+                      <type>xml</type>
+                      <prefix>NULL</prefix>
+                      <value>&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;%value%&lt;/roleTerm&gt;&lt;/role&gt;</value>
+                    </create>
+                    <read>
+                      <path>mods:role[mods:roleTerm = 'Degree grantor'] | mods:role[mods:roleTerm = 'Degree granting institution']</path>
+                      <context>parent</context>
+                    </read>
+                    <update>
+                      <path>mods:role/mods:roleTerm</path>
+                      <context>parent</context>
+                    </update>
+                    <delete>NULL</delete>
+                  </actions>
+                </properties>
+                <children/>
+              </element>
               <element name="institution">
                 <properties>
                   <type>textfield</type>

--- a/xml/thesis_form_ISLANDORA1350.xml
+++ b/xml/thesis_form_ISLANDORA1350.xml
@@ -443,7 +443,7 @@
           <multiple>FALSE</multiple>
           <required>FALSE</required>
           <resizable>FALSE</resizable>
-          <title>Degree Granter</title>
+          <title>Degree Granting Institution</title>
           <tree>TRUE</tree>
         </properties>
         <children>
@@ -466,10 +466,10 @@
                   <schema/>
                   <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree grantor&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
+                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree granting institution&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
                 </create>
                 <read>
-                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/..</path>
+                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/.. |  mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree granting institution']/..</path>
                   <context>parent</context>
                 </read>
                 <update>NULL</update>

--- a/xml/thesis_form_ISLANDORA1350.xml
+++ b/xml/thesis_form_ISLANDORA1350.xml
@@ -701,7 +701,7 @@
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <description>The year this book was issued.</description>
+              <description>The year this thesis was issued.</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
               <multiple>FALSE</multiple>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1988

# What does this Pull Request do?
Changes the `thesis_form.xml` and `thesis_form_ISLANDORA1350.xml` thesis forms to say "Degree granting institution" instead of "Degree grantor" in the form label and output value. Also enhances the form's xpath search so that MODS records generated with "Degree grantor" as the `roleTerm` still get found.

Note that only newly created 'Degree granting institution' names will have the newer `roleTerm`, older ones will still get loaded by the form, but will retain their original 'Degree grantor' `roleTerm`. I'm open to suggestions on ways to force the form to update this data though.

# How should this be tested?
Load up a VM and create a thesis object using the default thesis form. Make sure to add a "Degree granter", and inspect the produced MODS record. Then, load up this PR locally and edit the MODS record with the default form. You will see the original data you entered, but the label will be "Degree granting institution" instead. Create a new DGI, and once again inspect the created MODS record. The new DGI should have the new proper `roleTerm`, while the older DGI has the "Degree grantor" `roleTerm`.

# Additional Notes:
If anyone knows how to get the form to update pre-existing info and resave it with the new MODS attributes, LMK and I'll work this into the PR.

# Interested parties
@DiegoPino @bondjimbond @rosiel @DonRichards 