### PR TITLE
Implements ISLANDORA-1052 recommended changes

### DIFF
--- a/includes/coins.inc
+++ b/includes/coins.inc
@@ -350,9 +350,7 @@ function islandora_scholar_details($object) {
     extract($coins->renderView());
     return array(
       '#type' => 'item',
-      '#title' => t('MODS Metadata'),
       '#markup' => theme('table', array(
-        'header' => $headers,
         'rows' => $rows,
       )),
     );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -204,7 +204,7 @@ function islandora_scholar_get_metadata_display($object, $weight) {
     module_load_include('inc', 'islandora_scholar', 'includes/coins');
     $display = array(
       '#type' => 'fieldset',
-      '#title' => t('Metadata'),
+      '#title' => t('Details'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
       '#weight' => $weight,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1052

# What does this Pull Request do?

Makes the following changes to the COINS metadata display for citations/theses:
- Changes "Metadata" to "Details"
- Removes extraneous "MODS Metadata" subheader
- Removes weird blank table header

# What's new?
The COINS metadata display is changed to look more like the standard metadata display by removing specialist words that most users wouldn't understand.

## Old and busted:
![old](https://user-images.githubusercontent.com/3837461/37660848-bffeb5ce-2c29-11e8-969a-ad072b065154.png)

## Newly adjusted:
![new](https://user-images.githubusercontent.com/3837461/37660852-c3c444d0-2c29-11e8-9b3e-ea5cd3bdb08c.png)

# How should this be tested?
Load up a VM, create a citation object, and make sure that the "Use standard metadata display" option is unchecked in the Scholar config to ensure  you are using the COINS display. Look at the display, then switch to this PR branch and refresh to see the difference.

# Interested parties
@dmoses @DonRichards @DiegoPino @rosiel @bondjimbond 
