### PR TITLE
Revert "Updates thesis forms: s/Degree grantor/Degree granting institution/"

### DIFF
--- a/xml/thesis_form.xml
+++ b/xml/thesis_form.xml
@@ -478,7 +478,7 @@
           <multiple>FALSE</multiple>
           <required>FALSE</required>
           <resizable>FALSE</resizable>
-          <title>Degree Granting Institution</title>
+          <title>Degree Granter</title>
           <tree>TRUE</tree>
         </properties>
         <children>
@@ -501,16 +501,13 @@
                   <schema/>
                   <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>&lt;name type='corporate' authority='lcnaf'&gt;%value%&lt;/name&gt;</value>
+                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree grantor&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
                 </create>
                 <read>
-                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/.. |  mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree granting institution']/..</path>
+                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/..</path>
                   <context>parent</context>
                 </read>
-                <update>
-                  <path>self::node()</path>
-                  <context>self</context>
-                </update>
+                <update>NULL</update>
                 <delete>
                   <path>self::node()</path>
                   <context>self</context>
@@ -518,42 +515,6 @@
               </actions>
             </properties>
             <children>
-              <element name="role-roleterm">
-                <properties>
-                  <type>hidden</type>
-                  <access>TRUE</access>
-                  <collapsed>FALSE</collapsed>
-                  <collapsible>FALSE</collapsible>
-                  <description>A hidden field for the role "Degree granting institution" which will update instances of "Degree grantor".  The value 'Degree granting institution' is hard-coded under Advanced Form Controls. </description>
-                  <disabled>FALSE</disabled>
-                  <executes_submit_callback>FALSE</executes_submit_callback>
-                  <multiple>FALSE</multiple>
-                  <required>FALSE</required>
-                  <resizable>FALSE</resizable>
-                  <tree>TRUE</tree>
-                  <value>Degree granting institution</value>
-                  <actions>
-                    <create>
-                      <path>self::node()</path>
-                      <context>parent</context>
-                      <schema/>
-                      <type>xml</type>
-                      <prefix>NULL</prefix>
-                      <value>&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;%value%&lt;/roleTerm&gt;&lt;/role&gt;</value>
-                    </create>
-                    <read>
-                      <path>mods:role[mods:roleTerm = 'Degree grantor'] | mods:role[mods:roleTerm = 'Degree granting institution']</path>
-                      <context>parent</context>
-                    </read>
-                    <update>
-                      <path>mods:role/mods:roleTerm</path>
-                      <context>parent</context>
-                    </update>
-                    <delete>NULL</delete>
-                  </actions>
-                </properties>
-                <children/>
-              </element>
               <element name="institution">
                 <properties>
                   <type>textfield</type>
@@ -736,7 +697,7 @@
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <description>The year this thesis was issued.</description>
+              <description>The year this book was issued.</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
               <multiple>FALSE</multiple>

--- a/xml/thesis_form_ISLANDORA1350.xml
+++ b/xml/thesis_form_ISLANDORA1350.xml
@@ -443,7 +443,7 @@
           <multiple>FALSE</multiple>
           <required>FALSE</required>
           <resizable>FALSE</resizable>
-          <title>Degree Granting Institution</title>
+          <title>Degree Granter</title>
           <tree>TRUE</tree>
         </properties>
         <children>
@@ -466,16 +466,13 @@
                   <schema/>
                   <type>xml</type>
                   <prefix>NULL</prefix>
-                  <value>&lt;name type='corporate' authority='lcnaf'&gt;%value%&lt;/name&gt;</value>
+                  <value>&lt;name type='corporate' authority='lcnaf'&gt;&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;Degree grantor&lt;/roleTerm&gt;&lt;/role&gt;&lt;/name&gt;</value>
                 </create>
                 <read>
-                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/.. |  mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree granting institution']/..</path>
+                  <path>mods:name[@type='corporate' and @authority='lcnaf']/mods:role[mods:roleTerm = 'Degree grantor']/..</path>
                   <context>parent</context>
                 </read>
-                <update>
-                  <path>self::node()</path>
-                  <context>self</context>
-                </update>
+                <update>NULL</update>
                 <delete>
                   <path>self::node()</path>
                   <context>self</context>
@@ -483,42 +480,6 @@
               </actions>
             </properties>
             <children>
-              <element name="role-roleterm">
-                <properties>
-                  <type>hidden</type>
-                  <access>TRUE</access>
-                  <collapsed>FALSE</collapsed>
-                  <collapsible>FALSE</collapsible>
-                  <description>A hidden field for the role "Degree granting institution" which will update instances of "Degree grantor".  The value 'Degree granting institution' is hard-coded under Advanced Form Controls. </description>
-                  <disabled>FALSE</disabled>
-                  <executes_submit_callback>FALSE</executes_submit_callback>
-                  <multiple>FALSE</multiple>
-                  <required>FALSE</required>
-                  <resizable>FALSE</resizable>
-                  <tree>TRUE</tree>
-                  <value>Degree granting institution</value>
-                  <actions>
-                    <create>
-                      <path>self::node()</path>
-                      <context>parent</context>
-                      <schema/>
-                      <type>xml</type>
-                      <prefix>NULL</prefix>
-                      <value>&lt;role&gt;&lt;roleTerm authority="marcrelator" type="text"&gt;%value%&lt;/roleTerm&gt;&lt;/role&gt;</value>
-                    </create>
-                    <read>
-                      <path>mods:role[mods:roleTerm = 'Degree grantor'] | mods:role[mods:roleTerm = 'Degree granting institution']</path>
-                      <context>parent</context>
-                    </read>
-                    <update>
-                      <path>mods:role/mods:roleTerm</path>
-                      <context>parent</context>
-                    </update>
-                    <delete>NULL</delete>
-                  </actions>
-                </properties>
-                <children/>
-              </element>
               <element name="institution">
                 <properties>
                   <type>textfield</type>
@@ -701,7 +662,7 @@
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <description>The year this thesis was issued.</description>
+              <description>The year this book was issued.</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
               <multiple>FALSE</multiple>


### PR DESCRIPTION
Reverts Islandora/islandora_scholar#282

JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1988

The present approach taken in the pull request being reverted (updating metadata on the fly, only when editing with particular forms) is likely to lead to a significant period in which there is inconsistent metadata present in repositories. Additionally, there appear to be multiple uses of the deprecated role term "Degree grantor" elsewhere in the code base, in particular, two submodules of `islandora_scholar`:
* ["islandora_google_scholar" XPath looks for "Degree grantor" explicitly](https://github.com/Islandora/islandora_scholar/blob/6494ac2082a6fbf36e637ee716c0e21d107b87a6/modules/islandora_google_scholar/islandora_google_scholar.module#L176)
* ["citeproc" will map "dgg" as the old "Degree grantor" instead of the new "Degree granting institution"](https://github.com/Islandora/islandora_scholar/blob/b148d4a5f0a42cedfca87556fb0cb8f57499cf36/modules/citeproc/includes/marcrelator_conversion.inc#L82)

There's also some mention of this role term in [islandora_xml_forms](https://github.com/Islandora/islandora_xml_forms/blob/39674ce770bf52f803e5417f62d5e7682e7ec78b/elements/xml/relators.rdf#L1287)... should this be updated in some way? Is this file even used?

To minimize the window in which there can exist inconsistent metadata, it is likely preferable to update all entries with the deprecated value to the preferred in a batch process. This has the side effect of allowing the code where we _use_ the value to be simplified such that we only need to deal with the preferred value; though, it may be desirable to introduce configuration such that the old value may continue to be used by institutions which wish to delay updating their data. The batch process should probably follow much the same patterns as we have followed in other instances of updating data, with a [message emitted from a `hook_update_N()` implementation pointing at a drush script](https://github.com/Islandora/islandora_xacml_editor/blob/ed2cb7b5ad036470afa2e763d12c13849c611568/api/islandora_xacml_api.install#L396-L407).

In the interim, before this hypothetical batch process is written and ready, and other code updated to use the new value, it seems prudent to revert [the merged pull request](https://github.com/Islandora/islandora_scholar/pull/282).

Tagging, due to nature of issue and potential for inconsistencies popping up in the wild: @dannylamb