### PR TITLE
Initial WCAG 2.0 compliance work.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -92,7 +92,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       'image',
       array(
         'path' => "islandora/object/$object->id/datastream/PREVIEW/view",
-        'alt' => t('Preview Datastream'),
+        'alt' => t('PREVIEW Datastream'),
       )
     );
     if (isset($object['PDF']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PDF'])) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -39,6 +39,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       '#weight' => $i++,
     ),
   );
+
   if (isset($object['MODS']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS'])) {
     module_load_include('inc', 'islandora_scholar', 'includes/csl_select.form');
     $display['citation_select'] = drupal_get_form('islandora_scholar_citation_select_form', $object->id);
@@ -87,20 +88,32 @@ function islandora_scholar_get_view(AbstractObject $object) {
     );
   }
   elseif (isset($object['PREVIEW']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PREVIEW'])) {
-    $image = theme('image', array(
+    $image = theme(
+      'image',
+      array(
         'path' => "islandora/object/$object->id/datastream/PREVIEW/view",
-      ));
+        'alt' => t('Preview Datastream'),
+      )
+    );
     if (isset($object['PDF']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PDF'])) {
       $display['preview'] = array(
-        '#markup' => l($image, "islandora/object/$object->id/datastream/PDF/view", array(
+        '#markup' => l($image, "islandora/object/$object->id/datastream/PDF/view",
+          array(
             'html' => TRUE,
-          )),
+            'attributes' => array(
+              'alt' => t('PDF Datastream'),
+            ),
+          )
+        ),
         '#weight' => $display['preview']['#weight'],
       );
     }
     else {
       $display['preview'] = array(
         '#theme' => 'image',
+        '#attributes' => array(
+          'alt' => t('PDF Preview'),
+        ),
         '#path' => "islandora/object/$object/datastream/PREVIEW/view",
         '#weight' => $display['preview']['#weight'],
       );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -77,7 +77,6 @@ function islandora_scholar_get_view(AbstractObject $object) {
   else {
     $display['citation']['#markup'] = t('Unable to load MODS.');
   }
-
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $viewer = islandora_get_viewer(array(), 'islandora_scholar_viewers', $object);
 
@@ -101,7 +100,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
           array(
             'html' => TRUE,
             'attributes' => array(
-              'alt' => t('PDF Datastream'),
+              'title' => t('PDF Datastream'),
             ),
           )
         ),


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2217)

#WCAG Islandora Scholar JIRA Pull

aXe accessibility engine: https://www.deque.com/axe/
Web Accessibility inititive: https://www.w3.org/WAI/intro/wcag

# What does this Pull Request do?
The goal of this pull request is to bring islandora scholar into compliance with WCAG 2.0 standards.

It is important to note that this pull aims to address accessiblility violations as seen by the average, non authenticated users. Administrative pages remain unaffected.

# What's new?
Adds alt attributes to the preview datastream, alt datastream and PDF Preview datastream.

# How should this be tested?

The easiest way to test these changes locally:
- install the aXe browser plugin in your browser of choice (found here: https://www.deque.com/axe/).
- Recommended: Enable the ‘AT Subtheme’ found in the Adaptive Core (https://www.drupal.org/project/adaptivetheme). This theme is the closest to matching wcag 2.0 requirements i could find.
- Run the aXe tool on a compound object page, or another wcag 2.0 compliance testing toolkit, and examine the page for WCAG 2.0 violations sourced from this modules code.


# Interested parties
Tag (@bryjbrown @Islandora/7-x-1-x-committers)