### PR TITLE
Adds function to santize HTML elements from imported DOI metadata

### DIFF
--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -141,14 +141,28 @@ EOQ;
  */
 function drush_islandora_scholar_fix_doi_html_in_mods() {
   $action = drush_get_option('action', variable_get('islandora_doi_handle_imported_metadata', FALSE));
-  if (!$action) {
+  if (!in_array($action, array('strip','encode'))) {
     drush_print("This function requires an option, since the GUI variable of how
      to handle DOI imports is not set. Please use `--action=encode` or
      `--action=strip`. For more information use `drush help islandora-scholar-fix-doi-html-in-mods`.");
     exit;
   }
-  batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action));
-  drush_backend_batch_process();
+  $warnings = dt("WARNING: You are about to irrevocably alter datastream " .
+  "content in place. Backups of modified datastreams, pre-alterations, " .
+  "will be stored in Drupal's temporary:// directory. ");
+  $warnings .= ($action == 'strip') ?
+  dt("You have chosen to strip errant HTML tags - this will result in data loss.") :
+  dt("You have chosen to encode errant HTML tags - this will by default result in unencoded tags being displayed to the user.");
+  $warnings .= dt(" Are you sure you wish to continue? ");
+
+  if (drush_confirm($warnings)) {
+    batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action));
+    drush_backend_batch_process();
+  }
+  else {
+    drush_user_abort(dt('Exiting, no datastreams changed.'));
+    exit;
+  }
 }
 
 function islandora_scholar_fix_doi_html_in_mods_create_batch($action) {

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -149,13 +149,13 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
   }
   $warnings = dt("WARNING: You are about to irrevocably alter datastream " .
   "content in place. Backups of modified datastreams, pre-alterations, " .
-  "will be stored in Drupal's temporary:// directory. ");
+  "will be stored in Drupal's temporary:// directory. \n");
   $warnings .= ($action == 'strip') ?
-  dt("You have chosen to strip errant HTML tags - this will result in data loss.") :
-  dt("You have chosen to encode errant HTML tags - this will by default result in unencoded tags being displayed to the user.");
-  $warnings .= dt(" Are you sure you wish to continue? ");
+  dt("You have chosen to strip errant HTML tags - this will result in data loss.\n") :
+  dt("You have chosen to encode errant HTML tags - this will by default result in unencoded tags being displayed to the user.\n");
+  $warnings .= dt("Are you sure you wish to continue? \n");
 
-  if (drush_confirm($warnings)) {
+  if (drush_confirm($warnings, 2)) {
     batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action));
     drush_backend_batch_process();
   }

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -236,7 +236,7 @@ EOQ;
     unstructured_citation (not implemented in the doi translator).
     src: https://support.crossref.org/hc/en-us/articles/214532023
     */
-    foreach (array('title', 'subtitle') as $local_name) {
+    foreach (array('title', 'subTitle') as $local_name) {
       $dubious_nodes = $doc->getElementsByTagNameNS($namespace, $local_name);
       foreach ($dubious_nodes as $node) {
         if ($node->childNodes->length > 1) {
@@ -253,7 +253,7 @@ EOQ;
       drush_print("\n=========== Fixing {$object->id}. ========================================\n");
       drush_print("Old MODS datastream saved to temporary://$filename");
       module_load_include('inc', 'islandora_doi', 'includes/utilities');
-      foreach (array('title', 'subtitle') as $local_name) {
+      foreach (array('title', 'subTitle') as $local_name) {
         $dubious_nodes = $doc->getElementsByTagNameNS($namespace, $local_name);
         foreach ($dubious_nodes as $node) {
           $child_count = $node->childNodes->length;

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -151,8 +151,8 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
   "content in place. Backups of modified datastreams, pre-alterations, " .
   "will be stored in Drupal's temporary:// directory. \n");
   $warnings .= ($action == 'strip') ?
-  dt("You have chosen to strip errant HTML tags - this will result in data loss.\n") :
-  dt("You have chosen to encode errant HTML tags - this will by default result in unencoded tags being displayed to the user.\n");
+  dt("You have chosen to strip errant HTML tags - this will result in a loss of some markup information.\n") :
+  dt("You have chosen to encode errant HTML tags - this will by default result in HTML source tags being displayed to the user.\n");
   $warnings .= dt("Are you sure you wish to continue? \n");
 
   if (drush_confirm($warnings, 2)) {

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -141,7 +141,7 @@ EOQ;
  */
 function drush_islandora_scholar_fix_doi_html_in_mods() {
   $action = drush_get_option('action', variable_get('islandora_doi_handle_imported_metadata', FALSE));
-  if (!in_array($action, array('strip','encode'))) {
+  if (!in_array($action, array('strip', 'encode'))) {
     drush_print("This function requires an option, since the GUI variable of how
      to handle DOI imports is not set. Please use `--action=encode` or
      `--action=strip`. For more information use `drush help islandora-scholar-fix-doi-html-in-mods`.");
@@ -165,6 +165,9 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
   }
 }
 
+/**
+ * Batch info for drush command to update citations with HTML in MODS.
+ */
 function islandora_scholar_fix_doi_html_in_mods_create_batch($action) {
   return array(
     'operations' => array(
@@ -178,6 +181,9 @@ function islandora_scholar_fix_doi_html_in_mods_create_batch($action) {
   );
 }
 
+/**
+ * Batch operations for drush command to update citations with HTML in MODS.
+ */
 function islandora_scholar_fix_doi_html_in_mods_batch_operation($action, &$context) {
   $batch_size = 10;
   /* The islandora_doi_crossref_translator, which introduced the bug that this
@@ -226,8 +232,8 @@ EOQ;
     $doc->loadXML($object['MODS']->content);
     $needs_work = FALSE;
     /* The crossref metadata spec dictates that 'Face markup' can only be
-    present in title, subtitle, original_language_title, and unstructured_citation
-    (not implemented in the doi translator).
+    present in title, subtitle, original_language_title, and
+    unstructured_citation (not implemented in the doi translator).
     src: https://support.crossref.org/hc/en-us/articles/214532023
     */
     foreach (array('title', 'subtitle') as $local_name) {
@@ -240,7 +246,7 @@ EOQ;
     }
     if ($needs_work) {
       // Dump the original MODS to a backup file.
-      $filename = 'MODS-' . str_replace(':','_',$object->id) . '-' . format_date(time(), 'custom','Y-m-d-His') . '.xml';
+      $filename = 'MODS-' . str_replace(':', '_', $object->id) . '-' . format_date(time(), 'custom', 'Y-m-d-His') . '.xml';
       $mods_file = file_save_data($doc->saveXML(), "temporary://$filename");
       $mods_file->status &= ~FILE_STATUS_PERMANENT;
       file_save($mods_file);

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -160,13 +160,13 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
   if (!($audit || $dry_run || $modify_my_data)) {
     drush_print("This function requires one option of the following: --audit, --dry-run, --modify-my-data.");
     drush_print("USAGE:");
-    drush_invoke('help', ['islandora-scholar-fix-doi-html-in-mods']);
+    drush_invoke('help', array('islandora-scholar-fix-doi-html-in-mods'));
     exit;
   }
   if (($audit && $dry_run) || (($audit || $dry_run) && $modify_my_data)) {
     drush_print("This function requires ONLY one option of the following: --audit, --dry-run, --modify-my-data.");
     drush_print("USAGE:");
-    drush_invoke('help', ['islandora-scholar-fix-doi-html-in-mods']);
+    drush_invoke('help', array('islandora-scholar-fix-doi-html-in-mods'));
     exit;
   }
 

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -38,9 +38,20 @@ function islandora_scholar_drush_command() {
       'action' => array(
         'description' => 'Whether to strip (remove tags) or encode (into &lt; and &gt;) HTML entities. Can be "strip" or "encode".',
       ),
+      'audit' => array(
+        'description' => 'List the affected PIDs, but do not perform any modifications.',
+      ),
+      'dry-run' => array(
+        'description' => 'List the affected PIDs and the modifications that would result.',
+      ),
+      'modify-my-data' => array(
+        'description' => 'Update the affected datastreams.',
+      ),
     ),
     'examples' => array(
-      'drush -u 1 --action=strip islandora-scholar-fix-doi-html-in-mods' => dt('Strip html elements from citation objects\' title elements.'),
+      'drush -u 1 islandora-scholar-fix-doi-html-in-mods --audit' => dt('List objects found to have unruly HTML in MODS'),
+      'drush -u 1 islandora-scholar-fix-doi-html-in-mods --action=strip --dry-run' => dt('Show what changes would result from stripping HTML from MODS, but do not modify data.'),
+      'drush -u 1 islandora-scholar-fix-doi-html-in-mods --action=encode --modify-my-data' => dt('Encode HTML within MODS, modifying the datastreams in place and printing changes to drush output.'),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -141,37 +152,60 @@ EOQ;
  */
 function drush_islandora_scholar_fix_doi_html_in_mods() {
   $action = drush_get_option('action', variable_get('islandora_doi_handle_imported_metadata', FALSE));
-  if (!in_array($action, array('strip', 'encode'))) {
-    drush_print("This function requires an option, since the GUI variable of how
+  $audit = drush_get_option('audit', FALSE);
+  $dry_run = drush_get_option('dry-run', FALSE);
+  $modify_my_data = drush_get_option('modify-my-data', FALSE);
+
+  // Require one and only one of --audit, --dry-run, --encode.
+  if (!($audit || $dry_run || $modify_my_data)) {
+    drush_print("This function requires one option of the following: --audit, --dry-run, --encode.");
+    drush_print("USAGE:");
+    drush_invoke('help',['islandora-scholar-fix-doi-html-in-mods']);
+    exit;
+  }
+  if (($audit && $dry_run) || (($audit || $dry_run) && $modify_my_data)) {
+    drush_print("This function requires ONLY one option of the following: --audit, --dry-run, --encode.");
+    drush_print("USAGE:");
+    drush_invoke('help',['islandora-scholar-fix-doi-html-in-mods']);
+    exit;
+  }
+
+  // Require an action if --dry-run or --encode is selected.
+  if (($audit OR $dry_run) AND (!in_array($action, array('strip', 'encode')))) {
+    drush_print("This function requires an action option, since the GUI variable of how
      to handle DOI imports is not set. Please use `--action=encode` or
      `--action=strip`. For more information use `drush help islandora-scholar-fix-doi-html-in-mods`.");
     exit;
   }
-  $warnings = dt("WARNING: You are about to irrevocably alter datastream " .
-  "content in place. Backups of modified datastreams, pre-alterations, " .
-  "will be stored in Drupal's temporary:// directory. \n");
-  $warnings .= ($action == 'strip') ?
-  dt("You have chosen to strip errant HTML tags - this will result in a loss of some markup information.\n") :
-  dt("You have chosen to encode errant HTML tags - this will by default result in HTML source tags being displayed to the user.\n");
-  $warnings .= dt("Are you sure you wish to continue? \n");
 
-  if (drush_confirm($warnings, 2)) {
-    batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action));
-    drush_backend_batch_process();
+  $method = ($modify_my_data ? 'modify' : ($dry_run ? 'dry-run' : 'audit'));
+
+  // Confirm if modifying.
+  if ($modify_my_data) {
+    $warnings = dt("WARNING: You are about to alter datastream content in place.\n");
+    $warnings .= ($action == 'strip') ?
+      dt("You have chosen to strip errant HTML tags - this will result in a loss of some markup information.\n") :
+      dt("You have chosen to encode errant HTML tags - this will by default result in HTML source tags being displayed to the user.\n");
+    $warnings .= dt("Are you sure you wish to continue? \n");
+    if (!drush_confirm($warnings, 2)) {
+      drush_user_abort(dt('Exiting, no datastreams changed.'));
+      exit;
+    }
   }
-  else {
-    drush_user_abort(dt('Exiting, no datastreams changed.'));
-    exit;
-  }
+
+  batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action, $method));
+  drush_backend_batch_process();
+
+
 }
 
 /**
  * Batch info for drush command to update citations with HTML in MODS.
  */
-function islandora_scholar_fix_doi_html_in_mods_create_batch($action) {
+function islandora_scholar_fix_doi_html_in_mods_create_batch($action, $method) {
   return array(
     'operations' => array(
-      array('islandora_scholar_fix_doi_html_in_mods_batch_operation', array($action)),
+      array('islandora_scholar_fix_doi_html_in_mods_batch_operation', array($action, $method)),
     ),
     'title' => t('Updating MODS for citations...'),
     'init_message' => t('Preparing to update MODS.'),
@@ -184,7 +218,7 @@ function islandora_scholar_fix_doi_html_in_mods_create_batch($action) {
 /**
  * Batch operations for drush command to update citations with HTML in MODS.
  */
-function islandora_scholar_fix_doi_html_in_mods_batch_operation($action, &$context) {
+function islandora_scholar_fix_doi_html_in_mods_batch_operation($action, $method, &$context) {
   $batch_size = 10;
   /* The islandora_doi_crossref_translator, which introduced the bug that this
   fixes, is part of the DOI importer, which is hard-coded to
@@ -245,14 +279,11 @@ EOQ;
       }
     }
     if ($needs_work) {
-      // Dump the original MODS to a backup file.
-      $filename = 'MODS-' . str_replace(':', '_', $object->id) . '-' . format_date(time(), 'custom', 'Y-m-d-His') . '.xml';
-      $mods_file = file_save_data($doc->saveXML(), "temporary://$filename");
-      $mods_file->status &= ~FILE_STATUS_PERMANENT;
-      file_save($mods_file);
-      drush_print("\n=========== Fixing {$object->id}. ========================================\n");
-      drush_print("Old MODS datastream saved to temporary://$filename");
-      module_load_include('inc', 'islandora_doi', 'includes/utilities');
+      if ($method == 'audit') {
+        drush_print($object->id);
+        continue;
+      }
+      drush_print("\n===========  {$object->id}. ========================================\n");
       foreach (array('title', 'subTitle') as $local_name) {
         $dubious_nodes = $doc->getElementsByTagNameNS($namespace, $local_name);
         foreach ($dubious_nodes as $node) {
@@ -272,7 +303,9 @@ EOQ;
         }
       }
       drush_print("==========================================================================\n");
-      $object['MODS']->content = $doc->saveXML();
+      if ($method == 'modify') {
+        $object['MODS']->content = $doc->saveXML();
+      }
     }
   }
   $sandbox['offset'] += $batch_size;

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -158,20 +158,20 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
 
   // Require one and only one of --audit, --dry-run, --encode.
   if (!($audit || $dry_run || $modify_my_data)) {
-    drush_print("This function requires one option of the following: --audit, --dry-run, --encode.");
+    drush_print("This function requires one option of the following: --audit, --dry-run, --modify-my-data.");
     drush_print("USAGE:");
     drush_invoke('help',['islandora-scholar-fix-doi-html-in-mods']);
     exit;
   }
   if (($audit && $dry_run) || (($audit || $dry_run) && $modify_my_data)) {
-    drush_print("This function requires ONLY one option of the following: --audit, --dry-run, --encode.");
+    drush_print("This function requires ONLY one option of the following: --audit, --dry-run, --modify-my-data.");
     drush_print("USAGE:");
     drush_invoke('help',['islandora-scholar-fix-doi-html-in-mods']);
     exit;
   }
 
-  // Require an action if --dry-run or --encode is selected.
-  if (($audit OR $dry_run) AND (!in_array($action, array('strip', 'encode')))) {
+  // Require an action if --dry-run or --modify-my-data is selected.
+  if (($modify_my_data OR $dry_run) AND (!in_array($action, array('strip', 'encode')))) {
     drush_print("This function requires an action option, since the GUI variable of how
      to handle DOI imports is not set. Please use `--action=encode` or
      `--action=strip`. For more information use `drush help islandora-scholar-fix-doi-html-in-mods`.");

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -160,13 +160,13 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
   if (!($audit || $dry_run || $modify_my_data)) {
     drush_print("This function requires one option of the following: --audit, --dry-run, --modify-my-data.");
     drush_print("USAGE:");
-    drush_invoke('help',['islandora-scholar-fix-doi-html-in-mods']);
+    drush_invoke('help', ['islandora-scholar-fix-doi-html-in-mods']);
     exit;
   }
   if (($audit && $dry_run) || (($audit || $dry_run) && $modify_my_data)) {
     drush_print("This function requires ONLY one option of the following: --audit, --dry-run, --modify-my-data.");
     drush_print("USAGE:");
-    drush_invoke('help',['islandora-scholar-fix-doi-html-in-mods']);
+    drush_invoke('help', ['islandora-scholar-fix-doi-html-in-mods']);
     exit;
   }
 
@@ -195,8 +195,6 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
 
   batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action, $method));
   drush_backend_batch_process();
-
-
 }
 
 /**
@@ -205,7 +203,10 @@ function drush_islandora_scholar_fix_doi_html_in_mods() {
 function islandora_scholar_fix_doi_html_in_mods_create_batch($action, $method) {
   return array(
     'operations' => array(
-      array('islandora_scholar_fix_doi_html_in_mods_batch_operation', array($action, $method)),
+      array(
+        'islandora_scholar_fix_doi_html_in_mods_batch_operation',
+        array($action, $method),
+      ),
     ),
     'title' => t('Updating MODS for citations...'),
     'init_message' => t('Preparing to update MODS.'),

--- a/islandora_scholar.drush.inc
+++ b/islandora_scholar.drush.inc
@@ -28,6 +28,22 @@ function islandora_scholar_drush_command() {
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
+  $commands['islandora-scholar-fix-doi-html-in-mods'] = array(
+    'description' => dt('Update existing citations with bad MODS caused by DOI importer failing to deal with embedded markup.'),
+    'drupal dependencies' => array(
+      'islandora',
+      'islandora_scholar',
+    ),
+    'options' => array(
+      'action' => array(
+        'description' => 'Whether to strip (remove tags) or encode (into &lt; and &gt;) HTML entities. Can be "strip" or "encode".',
+      ),
+    ),
+    'examples' => array(
+      'drush -u 1 --action=strip islandora-scholar-fix-doi-html-in-mods' => dt('Strip html elements from citation objects\' title elements.'),
+    ),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+  );
   return $commands;
 }
 
@@ -116,5 +132,129 @@ EOQ;
     }
   }
   $sandbox['offset'] += $citation_update;
+  $context['finished'] = $sandbox['offset'] / $sandbox['total'];
+}
+
+
+/**
+ * Command callback to update citations with HTML in MODS.
+ */
+function drush_islandora_scholar_fix_doi_html_in_mods() {
+  $action = drush_get_option('action', variable_get('islandora_doi_handle_imported_metadata', FALSE));
+  if (!$action) {
+    drush_print("This function requires an option, since the GUI variable of how
+     to handle DOI imports is not set. Please use `--action=encode` or
+     `--action=strip`. For more information use `drush help islandora-scholar-fix-doi-html-in-mods`.");
+    exit;
+  }
+  batch_set(islandora_scholar_fix_doi_html_in_mods_create_batch($action));
+  drush_backend_batch_process();
+}
+
+function islandora_scholar_fix_doi_html_in_mods_create_batch($action) {
+  return array(
+    'operations' => array(
+      array('islandora_scholar_fix_doi_html_in_mods_batch_operation', array($action)),
+    ),
+    'title' => t('Updating MODS for citations...'),
+    'init_message' => t('Preparing to update MODS.'),
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
+    'error_message' => t('An error has occurred.'),
+    'file' => drupal_get_path('module', 'islandora_scholar') . '/islandora_scholar.drush.inc',
+  );
+}
+
+function islandora_scholar_fix_doi_html_in_mods_batch_operation($action, &$context) {
+  $batch_size = 10;
+  /* The islandora_doi_crossref_translator, which introduced the bug that this
+  fixes, is part of the DOI importer, which is hard-coded to
+  import only ir:citationCModel objects. If the repository manager has
+  changed the content models of imported objects, they are responsible for
+  finding and fixing any objects that need it.
+  */
+  $query = <<<EOQ
+SELECT ?pid FROM <#ri>
+WHERE {
+  ?pid <fedora-model:hasModel> <info:fedora/ir:citationCModel> ;
+       <fedora-view:disseminates> ?ds .
+  ?ds <fedora-view:disseminationType> <info:fedora/*/MODS> .
+}
+ORDER BY ?pid
+EOQ;
+  $connection = islandora_get_tuque_connection();
+
+  $sandbox = &$context['sandbox'];
+  if (!isset($sandbox['offset'])) {
+    $sparql_count = $connection->repository->ri->countQuery($query, 'sparql');
+    $sandbox['offset'] = 0;
+    $sandbox['total'] = $sparql_count;
+    if ($sandbox['total'] === 0) {
+      return;
+    }
+  }
+
+  $context['message'] = t('Processing results @start to @end.', array(
+    '@start' => $sandbox['offset'],
+    '@end' => min($sandbox['offset'] + $batch_size, $sandbox['total']),
+  ));
+
+  $offset_start = $sandbox['offset'];
+  $query .= "
+  LIMIT $batch_size
+  OFFSET $offset_start
+  ";
+  $results = $connection->repository->ri->sparqlQuery($query);
+  module_load_include('inc', 'islandora_doi', 'includes/utilities');
+  foreach ($results as $result) {
+    $object = islandora_object_load($result['pid']['value']);
+    $namespace = 'http://www.loc.gov/mods/v3';
+    $doc = new DOMDocument();
+    $doc->loadXML($object['MODS']->content);
+    $needs_work = FALSE;
+    /* The crossref metadata spec dictates that 'Face markup' can only be
+    present in title, subtitle, original_language_title, and unstructured_citation
+    (not implemented in the doi translator).
+    src: https://support.crossref.org/hc/en-us/articles/214532023
+    */
+    foreach (array('title', 'subtitle') as $local_name) {
+      $dubious_nodes = $doc->getElementsByTagNameNS($namespace, $local_name);
+      foreach ($dubious_nodes as $node) {
+        if ($node->childNodes->length > 1) {
+          $needs_work = TRUE;
+        }
+      }
+    }
+    if ($needs_work) {
+      // Dump the original MODS to a backup file.
+      $filename = 'MODS-' . str_replace(':','_',$object->id) . '-' . format_date(time(), 'custom','Y-m-d-His') . '.xml';
+      $mods_file = file_save_data($doc->saveXML(), "temporary://$filename");
+      $mods_file->status &= ~FILE_STATUS_PERMANENT;
+      file_save($mods_file);
+      drush_print("\n=========== Fixing {$object->id}. ========================================\n");
+      drush_print("Old MODS datastream saved to temporary://$filename");
+      module_load_include('inc', 'islandora_doi', 'includes/utilities');
+      foreach (array('title', 'subtitle') as $local_name) {
+        $dubious_nodes = $doc->getElementsByTagNameNS($namespace, $local_name);
+        foreach ($dubious_nodes as $node) {
+          $child_count = $node->childNodes->length;
+          if ($child_count > 1) {
+            $old_value = $node->ownerDocument->saveXML($node);
+            $sanitized_content = new DOMText(islandora_doi_filter_html($node, $action));
+            for ($i = 0; $i < $child_count; $i++) {
+              $node->removeChild($node->childNodes->item(0));
+            }
+            $node->appendChild($sanitized_content);
+            $new_value = $node->ownerDocument->saveXML($node);
+
+            drush_print("OLD VALUE:\n$old_value");
+            drush_print("NEW VALUE:\n$new_value");
+          }
+        }
+      }
+      drush_print("==========================================================================\n");
+      $object['MODS']->content = $doc->saveXML();
+    }
+  }
+  $sandbox['offset'] += $batch_size;
   $context['finished'] = $sandbox['offset'] / $sandbox['total'];
 }

--- a/modules/doi/includes/admin.form.inc
+++ b/modules/doi/includes/admin.form.inc
@@ -30,7 +30,7 @@ function islandora_doi_admin_form(array $form, array &$form_state) {
     'islandora_doi_handle_imported_metadata' => array(
       '#type' => 'radios',
       '#title' => t('How should embedded HTML in imported DOI metadata be handled?'),
-      '#description' => t('For example, stripping tags will change "H&lt;sub&gt;2&lt;/sub&gt;O" to "H2O". Encoding tags will change  "H&lt;sub&gt;2&lt;/sub&gt;O" to  "H&amp;lt;sub&amp;gt;2&amp;lt;/sub&amp;gt;O". Re-encoding tags for display is not yet implemented in Islandora.'),
+      '#description' => t('For example, stripping tags will change "H&lt;sub&gt;2&lt;/sub&gt;O" to "H2O". Encoding tags will change  "H&lt;sub&gt;2&lt;/sub&gt;O" to  "H&amp;lt;sub&amp;gt;2&amp;lt;/sub&amp;gt;O". Re-decoding tags for display is not yet implemented in Islandora.'),
       '#options' => array(
         'strip' => t('Strip embedded HTML tags'),
         'encode' => t('Encode embedded HTML tags'),

--- a/modules/doi/includes/admin.form.inc
+++ b/modules/doi/includes/admin.form.inc
@@ -35,7 +35,7 @@ function islandora_doi_admin_form(array $form, array &$form_state) {
         'strip' => t('Strip embedded HTML tags'),
         'encode' => t('Encode embedded HTML tags'),
       ),
-      '#default_value' => variable_get('islandora_doi_handle_imported_metadata'),
+      '#default_value' => variable_get('islandora_doi_handle_imported_metadata', 'strip'),
     ),
 
     'islandora_doi_url_config' => array(

--- a/modules/doi/includes/admin.form.inc
+++ b/modules/doi/includes/admin.form.inc
@@ -22,11 +22,22 @@ function islandora_doi_admin_form(array $form, array &$form_state) {
     'islandora_doi_use_legacy_mode' => array(
       '#type' => 'checkbox',
       '#title' => t('Use legacy retrieval mode'),
-      '#description' => t("Keep fetching metadata directly from CrossREF's OpenURL (account required!). If unchecked, use content negotiation as explained by https://www.crosscite.org."),
+      '#description' => t("Keep fetching metadata directly from Crossref's OpenURL (account required!). If unchecked, use content negotiation as explained by https://www.crosscite.org."),
       '#default_value' => (islandora_doi_use_legacy_mode() === TRUE ? 1 : 0),
       // Ensure correct return value if selected (although 1 is the default).
       '#return_value' => 1,
     ),
+    'islandora_doi_handle_imported_metadata' => array(
+      '#type' => 'radios',
+      '#title' => t('How should embedded HTML in imported DOI metadata be handled?'),
+      '#description' => t('For example, stripping tags will change "H&lt;sub&gt;2&lt;/sub&gt;O" to "H2O". Encoding tags will change  "H&lt;sub&gt;2&lt;/sub&gt;O" to  "H&amp;lt;sub&amp;gt;2&amp;lt;/sub&amp;gt;O". Re-encoding tags for display is not yet implemented in Islandora.'),
+      '#options' => array(
+        'strip' => t('Strip embedded HTML tags'),
+        'encode' => t('Encode embedded HTML tags'),
+      ),
+      '#default_value' => variable_get('islandora_doi_handle_imported_metadata'),
+    ),
+
     'islandora_doi_url_config' => array(
       '#type' => 'fieldset',
       '#title' => t('DOI URL configuration'),

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -871,7 +871,6 @@ function islandora_doi_filter_html($text, $removals = FALSE) {
     $text = "";
   }
   else {
-
     if ($removals) {
       foreach ($removals as $removal) {
         $text = str_replace($removal, '', $text);
@@ -888,7 +887,7 @@ function islandora_doi_filter_html($text, $removals = FALSE) {
         break;
 
       default:
-        drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => variable_get('islandora_doi_handle_imported_metadata', 'strip'))), 'error'); 
+        drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => variable_get('islandora_doi_handle_imported_metadata', 'strip'))), 'error');
         break;
 
     }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -888,7 +888,7 @@ function islandora_doi_filter_html($doi_domdoc, $doi_child_node, $element_name =
     $element_text = str_replace("<{$element_name}>", '', $element_text);
     $element_text = str_replace("</{$element_name}>", '', $element_text);
   }
-  switch (variable_get('islandora_doi_handle_imported_metadata')) {
+  switch (variable_get('islandora_doi_handle_imported_metadata', 'strip')) {
     case 'strip':
       $element_text = strip_tags($element_text);
       break;

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -202,36 +202,39 @@ function islandora_doi_crossref_translator($crossref_data) {
       foreach ($metadata->childNodes as $child) {
         switch ($child->nodeName) {
           case 'full_title':
+            $titleinfo = $mods->createElement('titleInfo');
+            $relateditem->appendChild($titleinfo);
+            $title = $mods->createElement('title');
+            $titleinfo->appendChild($title);
             if (!is_null($child->firstChild)) {
-              $titleinfo = $mods->createElement('titleInfo');
-              $relateditem->appendChild($titleinfo);
-              $title_text = islandora_doi_filter_html($child);
-              $title = $mods->createElement('title', $title_text);
-              $titleinfo->appendChild($title);
+              $title_text = $mods->importNode($child->firstChild);
+              $title->appendChild($title_text);
             }
             break;
 
           case 'abbrev_title':
+            $titleinfo = $mods->createElement('titleInfo');
+            $titleinfo_attribute = $mods->createAttribute('type');
+            $titleinfo_attribute->value = 'abbreviated';
+            $titleinfo->appendChild($titleinfo_attribute);
+            $relateditem->appendChild($titleinfo);
+            $title = $mods->createElement('title');
+            $titleinfo->appendChild($title);
             if (!is_null($child->firstChild)) {
-              $titleinfo = $mods->createElement('titleInfo');
-              $titleinfo_attribute = $mods->createAttribute('type');
-              $titleinfo_attribute->value = 'abbreviated';
-              $titleinfo->appendChild($titleinfo_attribute);
-              $relateditem->appendChild($titleinfo);
-              $title_text = islandora_doi_filter_html($child);
-              $title = $mods->createElement('title', $title_text);
-              $titleinfo->appendChild($title);
+              $title_text = $mods->importNode($child->firstChild);
+              $title->appendChild($title_text);
             }
             break;
 
           case 'issn':
+            $identifier = $mods->createElement('identifier');
+            $identifier_attribute = $mods->createAttribute('type');
+            $identifier_attribute->value = 'issn';
+            $identifier->appendChild($identifier_attribute);
+            $relateditem->appendChild($identifier);
             if (!is_null($child->firstChild)) {
-              $identifier_text = islandora_doi_filter_html($child);
-              $identifier = $mods->createElement('identifier', $identifier_text);
-              $identifier_attribute = $mods->createAttribute('type');
-              $identifier_attribute->value = 'issn';
-              $identifier->appendChild($identifier_attribute);
-              $relateditem->appendChild($identifier);
+              $identifier_text = $mods->importNode($child->firstChild);
+              $identifier->appendChild($identifier_text);
             }
             break;
         }
@@ -246,15 +249,15 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($child->childNodes as $date_part) {
                   switch ($date_part->nodeName) {
                     case 'month':
-                      $pubdate_month = islandora_doi_filter_html($date_part);
+                      $pubdate_month = $date_part->nodeValue;
                       break;
 
                     case 'year':
-                      $pubdate_year = islandora_doi_filter_html($date_part);
+                      $pubdate_year = $date_part->nodeValue;
                       break;
 
                     case 'day':
-                      $pubdate_day = islandora_doi_filter_html($date_part);
+                      $pubdate_day = $date_part->nodeValue;
                       break;
                   }
                 }
@@ -358,15 +361,16 @@ function islandora_doi_crossref_translator($crossref_data) {
 
             case 'contributors':
               foreach ($child->getElementsByTagName('organization') as $organization) {
+                $name = $mods->createElement('name');
+                $mods->firstChild->appendChild($name);
+                $name_attribute = $mods->createAttribute('type');
+                $name_attribute->value = 'corporate';
+                $name->appendChild($name_attribute);
+                $namepart = $mods->createElement('namePart');
+                $name->appendChild($namepart);
                 if (!is_null($organization->firstChild)) {
-                  $name = $mods->createElement('name');
-                  $mods->firstChild->appendChild($name);
-                  $name_attribute = $mods->createAttribute('type');
-                  $name_attribute->value = 'corporate';
-                  $name->appendChild($name_attribute);
-                  $namepart_text = islandora_doi_filter_html($organization);
-                  $namepart = $mods->createElement('namePart');
-                  $name->appendChild($namepart);
+                  $namepart_text = $mods->importNode($organization->firstChild);
+                  $namepart->appendChild($namepart_text);
                 }
               }
 
@@ -380,43 +384,47 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($person->childNodes as $person_part) {
                   switch ($person_part->nodeName) {
                     case 'given_name':
+                      $namepart = $mods->createElement('namePart');
+                      $name->appendChild($namepart);
+                      $namepart_attribute = $mods->createAttribute('type');
+                      $namepart_attribute->value = 'given';
+                      $namepart->appendChild($namepart_attribute);
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($person_part);
-                        $namepart = $mods->createElement('namePart', $name_text);
-                        $name->appendChild($namepart);
-                        $namepart_attribute = $mods->createAttribute('type');
-                        $namepart_attribute->value = 'given';
-                        $namepart->appendChild($namepart_attribute);
+                        $given_name_part = $mods->importNode($person_part->firstChild);
+                        $namepart->appendChild($given_name_part);
                       }
                       break;
 
                     case 'surname':
+                      $namepart = $mods->createElement('namePart');
+                      $name->appendChild($namepart);
+                      $namepart_attribute = $mods->createAttribute('type');
+                      $namepart_attribute->value = 'family';
+                      $namepart->appendChild($namepart_attribute);
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($person_part);
-                        $namepart = $mods->createElement('namePart', $name_text);
-                        $name->appendChild($namepart);
-                        $namepart_attribute = $mods->createAttribute('type');
-                        $namepart_attribute->value = 'family';
-                        $namepart->appendChild($namepart_attribute);
+                        $surname_part = $mods->importNode($person_part->firstChild);
+                        $namepart->appendChild($surname_part);
                       }
                       break;
 
                     case 'suffix':
+                      $terms_of_address = $mods->createElement('namePart');
+                      $name->appendChild($terms_of_address);
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($person_part);
-                        $terms_of_address = $mods->createElement('namePart', $name_text);
-                        $name->appendChild($terms_of_address);
-                        $terms_of_address_attribute = $mods->createAttribute('type');
-                        $terms_of_address_attribute->value = 'termsOfAddress';
-                        $terms_of_address->appendChild($terms_of_address_attribute);
+                        $terms_of_address_text = $mods->importNode($person_part->firstChild);
+                        $terms_of_address->appendChild($terms_of_address_text);
                       }
+                      $terms_of_address_attribute = $mods->createAttribute('type');
+                      $terms_of_address_attribute->value = 'termsOfAddress';
+                      $terms_of_address->appendChild($terms_of_address_attribute);
                       break;
 
                     case 'affiliation':
+                      $affiliation = $mods->createElement('affiliation');
+                      $name->appendChild($affiliation);
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($person_part);
-                        $affiliation = $mods->createElement('affiliation', $name_text);
-                        $name->appendChild($affiliation);
+                        $affiliation_text = $mods->importNode($person_part->firstChild);
+                        $affiliation->appendChild($affiliation_text);
                       }
                       break;
                   }
@@ -427,10 +435,10 @@ function islandora_doi_crossref_translator($crossref_data) {
                     case 'contributor_role':
                       $role = $mods->createElement('role');
                       $name->appendChild($role);
-                      $roleterm_text = strtolower(islandora_doi_filter_html($att));
-                      $roleterm = $mods->createElement('roleTerm', $roleterm_text);
+                      $roleterm = $mods->createElement('roleTerm');
                       $role->appendChild($roleterm);
-
+                      $roleterm_text = $mods->createTextNode(strtolower($att->nodeValue));
+                      $roleterm->appendChild($roleterm_text);
                       $roles = array('author', 'editor', 'translator');
                       if (in_array(strtolower($att->nodeValue), $roles)) {
                         $roleterm_attribute = $mods->createAttribute('authority');
@@ -460,15 +468,15 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($child->childNodes as $date_part) {
                   switch ($date_part->nodeName) {
                     case 'month':
-                      $pubdate_month = islandora_doi_filter_html($date_part);
+                      $pubdate_month = $date_part->nodeValue;
                       break;
 
                     case 'year':
-                      $pubdate_year = islandora_doi_filter_html($date_part);
+                      $pubdate_year = $date_part->nodeValue;
                       break;
 
                     case 'day':
-                      $pubdate_day = islandora_doi_filter_html($date_part);
+                      $pubdate_day = $date_part->nodeValue;
                       break;
                   }
                 }
@@ -515,23 +523,25 @@ function islandora_doi_crossref_translator($crossref_data) {
                   switch ($identifier->nodeName) {
                     case 'doi':
                       if (!is_null($identifier->firstChild)) {
-                        $doi_text = islandora_doi_filter_html($identifier);
-                        $doi = $mods->createElement('identifier', $doi_text);
+                        $doi = $mods->createElement('identifier');
                         $mods->firstChild->appendChild($doi);
                         $doi_attribute = $mods->createAttribute('type');
                         $doi_attribute->value = 'doi';
                         $doi->appendChild($doi_attribute);
+                        $doi_text = $mods->importNode($identifier->firstChild);
+                        $doi->appendChild($doi_text);
                       }
                       break;
 
                     case 'resource':
                       if (!is_null($identifier->firstChild)) {
-                        $uri_text = islandora_doi_filter_html($identifier);
-                        $uri = $mods->createElement('identifier', $uri_text);
+                        $uri = $mods->createElement('identifier');
                         $mods->firstChild->appendChild($uri);
                         $uri_attribute = $mods->createAttribute('type');
                         $uri_attribute->value = 'uri';
                         $uri->appendChild($uri_attribute);
+                        $uri_text = $mods->importNode($identifier->firstChild);
+                        $uri->appendChild($uri_text);
                       }
                       break;
                   }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -176,7 +176,6 @@ function islandora_doi_perform_request($id_or_url) {
  */
 function islandora_doi_crossref_translator($crossref_data) {
   // Parse the source into a DOMDocument.
-  watchdog('test', htmlentities($crossref_data));
   $crossref_xml = new DOMDocument("1.0");
   if (!$crossref_xml->loadXML($crossref_data)) {
     return FALSE;
@@ -203,31 +202,37 @@ function islandora_doi_crossref_translator($crossref_data) {
       foreach ($metadata->childNodes as $child) {
         switch ($child->nodeName) {
           case 'full_title':
-            $titleinfo = $mods->createElement('titleInfo');
-            $relateditem->appendChild($titleinfo);
-            $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
-            $title = $mods->createElement('title', $title_text);
-            $titleinfo->appendChild($title);
+            if (!is_null($child->firstChild)) {
+              $titleinfo = $mods->createElement('titleInfo');
+              $relateditem->appendChild($titleinfo);
+              $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+              $title = $mods->createElement('title', $title_text);
+              $titleinfo->appendChild($title);
+            }
             break;
 
           case 'abbrev_title':
-            $titleinfo = $mods->createElement('titleInfo');
-            $titleinfo_attribute = $mods->createAttribute('type');
-            $titleinfo_attribute->value = 'abbreviated';
-            $titleinfo->appendChild($titleinfo_attribute);
-            $relateditem->appendChild($titleinfo);
-            $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
-            $title = $mods->createElement('title', $title_text);
-            $titleinfo->appendChild($title);
+            if (!is_null($child->firstChild)) {
+              $titleinfo = $mods->createElement('titleInfo');
+              $titleinfo_attribute = $mods->createAttribute('type');
+              $titleinfo_attribute->value = 'abbreviated';
+              $titleinfo->appendChild($titleinfo_attribute);
+              $relateditem->appendChild($titleinfo);
+              $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+              $title = $mods->createElement('title', $title_text);
+              $titleinfo->appendChild($title);
+            }
             break;
 
           case 'issn':
-            $identifier_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
-            $identifier = $mods->createElement('identifier', $identifier_text);
-            $identifier_attribute = $mods->createAttribute('type');
-            $identifier_attribute->value = 'issn';
-            $identifier->appendChild($identifier_attribute);
-            $relateditem->appendChild($identifier);
+            if (!is_null($child->firstChild)) {
+              $identifier_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+              $identifier = $mods->createElement('identifier', $identifier_text);
+              $identifier_attribute = $mods->createAttribute('type');
+              $identifier_attribute->value = 'issn';
+              $identifier->appendChild($identifier_attribute);
+              $relateditem->appendChild($identifier);
+            }
             break;
         }
       }
@@ -311,15 +316,19 @@ function islandora_doi_crossref_translator($crossref_data) {
               foreach ($child->childNodes as $grandchild) {
                 switch ($grandchild->nodeName) {
                   case 'title':
-                    $article_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild), array('<title>', '</title>'));
-                    $article_title = $mods->createElement('title', $article_title_text);
-                    $titleinfo->appendChild($article_title);
+                    if (!is_null($grandchild)) {
+                      $article_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild), array('<title>', '</title>'));
+                      $article_title = $mods->createElement('title', $article_title_text);
+                      $titleinfo->appendChild($article_title);
+                    }
                     break;
 
                   case 'subtitle':
-                    $article_subtitle_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
-                    $article_subtitle = $mods->createElement('subTitle', $article_subtitle_text);
-                    $titleinfo->appendChild($article_subtitle);
+                    if (!is_null($grandchild->firstChild)) {
+                      $article_subtitle_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
+                      $article_subtitle = $mods->createElement('subTitle', $article_subtitle_text);
+                      $titleinfo->appendChild($article_subtitle);
+                    }
                     break;
 
                   case 'original_language_title':
@@ -337,10 +346,11 @@ function islandora_doi_crossref_translator($crossref_data) {
                           break;
                       }
                     }
-
-                    $translated_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
-                    $translated_title = $mods->createElement('title', $translated_title_text);
-                    $translated_titleinfo->appendChild($translated_title);
+                    if (!is_null($grandchild->firstChild)) {
+                      $translated_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
+                      $translated_title = $mods->createElement('title', $translated_title_text);
+                      $translated_titleinfo->appendChild($translated_title);
+                    }
                     break;
                 }
               }
@@ -348,14 +358,16 @@ function islandora_doi_crossref_translator($crossref_data) {
 
             case 'contributors':
               foreach ($child->getElementsByTagName('organization') as $organization) {
-                $name = $mods->createElement('name');
-                $mods->firstChild->appendChild($name);
-                $name_attribute = $mods->createAttribute('type');
-                $name_attribute->value = 'corporate';
-                $name->appendChild($name_attribute);
-                $namepart_text = islandora_doi_filter_html($crossref_xml->saveXML($organization->firstChild));
-                $namepart = $mods->createElement('namePart');
-                $name->appendChild($namepart);
+                if (!is_null($organization->firstChild)) {
+                  $name = $mods->createElement('name');
+                  $mods->firstChild->appendChild($name);
+                  $name_attribute = $mods->createAttribute('type');
+                  $name_attribute->value = 'corporate';
+                  $name->appendChild($name_attribute);
+                  $namepart_text = islandora_doi_filter_html($crossref_xml->saveXML($organization->firstChild));
+                  $namepart = $mods->createElement('namePart');
+                  $name->appendChild($namepart);
+                }
               }
 
               foreach ($child->getElementsByTagName('person_name') as $person) {
@@ -368,36 +380,44 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($person->childNodes as $person_part) {
                   switch ($person_part->nodeName) {
                     case 'given_name':
-                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
-                      $namepart = $mods->createElement('namePart', $name_text);
-                      $name->appendChild($namepart);
-                      $namepart_attribute = $mods->createAttribute('type');
-                      $namepart_attribute->value = 'given';
-                      $namepart->appendChild($namepart_attribute);
+                      if (!is_null($person_part->firstChild)) {
+                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $namepart = $mods->createElement('namePart', $name_text);
+                        $name->appendChild($namepart);
+                        $namepart_attribute = $mods->createAttribute('type');
+                        $namepart_attribute->value = 'given';
+                        $namepart->appendChild($namepart_attribute);
+                      }
                       break;
 
                     case 'surname':
-                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
-                      $namepart = $mods->createElement('namePart', $name_text);
-                      $name->appendChild($namepart);
-                      $namepart_attribute = $mods->createAttribute('type');
-                      $namepart_attribute->value = 'family';
-                      $namepart->appendChild($namepart_attribute);
+                      if (!is_null($person_part->firstChild)) {
+                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $namepart = $mods->createElement('namePart', $name_text);
+                        $name->appendChild($namepart);
+                        $namepart_attribute = $mods->createAttribute('type');
+                        $namepart_attribute->value = 'family';
+                        $namepart->appendChild($namepart_attribute);
+                      }
                       break;
 
                     case 'suffix':
-                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
-                      $terms_of_address = $mods->createElement('namePart', $name_text);
-                      $name->appendChild($terms_of_address);
-                      $terms_of_address_attribute = $mods->createAttribute('type');
-                      $terms_of_address_attribute->value = 'termsOfAddress';
-                      $terms_of_address->appendChild($terms_of_address_attribute);
+                      if (!is_null($person_part->firstChild)) {
+                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $terms_of_address = $mods->createElement('namePart', $name_text);
+                        $name->appendChild($terms_of_address);
+                        $terms_of_address_attribute = $mods->createAttribute('type');
+                        $terms_of_address_attribute->value = 'termsOfAddress';
+                        $terms_of_address->appendChild($terms_of_address_attribute);
+                      }
                       break;
 
                     case 'affiliation':
-                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
-                      $affiliation = $mods->createElement('affiliation', $name_text);
-                      $name->appendChild($affiliation);
+                      if (!is_null($person_part->firstChild)) {
+                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $affiliation = $mods->createElement('affiliation', $name_text);
+                        $name->appendChild($affiliation);
+                      }
                       break;
                   }
                 }
@@ -839,6 +859,7 @@ function islandora_doi_get_mods($id) {
  *
  * @param string $text
  *   The text of the metadata to be filtered 
+ *
  * @param array $removals
  *   An array of strings to be removed from $text prior to filtering
  *
@@ -846,24 +867,31 @@ function islandora_doi_get_mods($id) {
  *   String filtered using value of $islandora_doi_handle_improted_metadata 
  */
 function islandora_doi_filter_html($text, $removals = FALSE) {
-  if ($removals) {
-    foreach ($removals as $removal) {
-      $text = str_replace($removal, '', $text);
-    }
+  if (!$text) {
+    $text = "";
   }
+  else {
 
-  switch (variable_get('islandora_doi_handle_imported_metadata', 'strip')) {
-    case 'strip':
-      $text = strip_tags($text);
-      break;
+    if ($removals) {
+      foreach ($removals as $removal) {
+        $text = str_replace($removal, '', $text);
+      }
+    }
 
-    case 'encode':
-      $text = htmlspecialchars($text);
-      break;
+    switch (variable_get('islandora_doi_handle_imported_metadata', 'strip')) {
+      case 'strip':
+        $text = strip_tags($text);
+        break;
 
-    default:
-      break;
+      case 'encode':
+        $text = htmlspecialchars($text);
+        break;
 
+      default:
+        drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => variable_get('islandora_doi_handle_imported_metadata', 'strip'))), 'error'); 
+        break;
+
+    }
   }
 
   return $text;

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -176,6 +176,7 @@ function islandora_doi_perform_request($id_or_url) {
  */
 function islandora_doi_crossref_translator($crossref_data) {
   // Parse the source into a DOMDocument.
+  watchdog('test', htmlentities($crossref_data));
   $crossref_xml = new DOMDocument("1.0");
   if (!$crossref_xml->loadXML($crossref_data)) {
     return FALSE;
@@ -204,12 +205,9 @@ function islandora_doi_crossref_translator($crossref_data) {
           case 'full_title':
             $titleinfo = $mods->createElement('titleInfo');
             $relateditem->appendChild($titleinfo);
-            $title = $mods->createElement('title');
+            $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+            $title = $mods->createElement('title', $title_text);
             $titleinfo->appendChild($title);
-            if (!is_null($child->firstChild)) {
-              $title_text = $mods->importNode($child->firstChild);
-              $title->appendChild($title_text);
-            }
             break;
 
           case 'abbrev_title':
@@ -218,24 +216,18 @@ function islandora_doi_crossref_translator($crossref_data) {
             $titleinfo_attribute->value = 'abbreviated';
             $titleinfo->appendChild($titleinfo_attribute);
             $relateditem->appendChild($titleinfo);
-            $title = $mods->createElement('title');
+            $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+            $title = $mods->createElement('title', $title_text);
             $titleinfo->appendChild($title);
-            if (!is_null($child->firstChild)) {
-              $title_text = $mods->importNode($child->firstChild);
-              $title->appendChild($title_text);
-            }
             break;
 
           case 'issn':
-            $identifier = $mods->createElement('identifier');
+            $identifier_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+            $identifier = $mods->createElement('identifier', $identifier_text);
             $identifier_attribute = $mods->createAttribute('type');
             $identifier_attribute->value = 'issn';
             $identifier->appendChild($identifier_attribute);
             $relateditem->appendChild($identifier);
-            if (!is_null($child->firstChild)) {
-              $identifier_text = $mods->importNode($child->firstChild);
-              $identifier->appendChild($identifier_text);
-            }
             break;
         }
       }
@@ -249,15 +241,15 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($child->childNodes as $date_part) {
                   switch ($date_part->nodeName) {
                     case 'month':
-                      $pubdate_month = $date_part->nodeValue;
+                      $pubdate_month = islandora_doi_filter_html($date_part->nodeValue);
                       break;
 
                     case 'year':
-                      $pubdate_year = $date_part->nodeValue;
+                      $pubdate_year = islandora_doi_filter_html($date_part->nodeValue);
                       break;
 
                     case 'day':
-                      $pubdate_day = $date_part->nodeValue;
+                      $pubdate_day = islandora_doi_filter_html($date_part->nodeValue);
                       break;
                   }
                 }
@@ -319,17 +311,14 @@ function islandora_doi_crossref_translator($crossref_data) {
               foreach ($child->childNodes as $grandchild) {
                 switch ($grandchild->nodeName) {
                   case 'title':
-                    $article_title_text = islandora_doi_filter_html($crossref_xml, $grandchild, "title");
+                    $article_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild), array('<title>', '</title>'));
                     $article_title = $mods->createElement('title', $article_title_text);
                     $titleinfo->appendChild($article_title);
                     break;
 
                   case 'subtitle':
-                    $article_subtitle = $mods->createElement('subTitle');
-                    if (!is_null($grandchild->firstChild)) {
-                      $article_subtitle_text = $mods->importNode($grandchild->firstChild, TRUE);
-                      $article_subtitle->appendChild($article_subtitle_text);
-                    }
+                    $article_subtitle_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
+                    $article_subtitle = $mods->createElement('subTitle', $article_subtitle_text);
                     $titleinfo->appendChild($article_subtitle);
                     break;
 
@@ -349,12 +338,9 @@ function islandora_doi_crossref_translator($crossref_data) {
                       }
                     }
 
-                    $translated_title = $mods->createElement('title');
+                    $translated_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
+                    $translated_title = $mods->createElement('title', $translated_title_text);
                     $translated_titleinfo->appendChild($translated_title);
-                    if (!is_null($grandchild->firstChild)) {
-                      $translated_title_text = $mods->importNode($grandchild->firstChild);
-                      $translated_title->appendChild($translated_title_text);
-                    }
                     break;
                 }
               }
@@ -367,12 +353,9 @@ function islandora_doi_crossref_translator($crossref_data) {
                 $name_attribute = $mods->createAttribute('type');
                 $name_attribute->value = 'corporate';
                 $name->appendChild($name_attribute);
+                $namepart_text = islandora_doi_filter_html($crossref_xml->saveXML($organization->firstChild));
                 $namepart = $mods->createElement('namePart');
                 $name->appendChild($namepart);
-                if (!is_null($organization->firstChild)) {
-                  $namepart_text = $mods->importNode($organization->firstChild);
-                  $namepart->appendChild($namepart_text);
-                }
               }
 
               foreach ($child->getElementsByTagName('person_name') as $person) {
@@ -385,48 +368,36 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($person->childNodes as $person_part) {
                   switch ($person_part->nodeName) {
                     case 'given_name':
-                      $namepart = $mods->createElement('namePart');
+                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                      $namepart = $mods->createElement('namePart', $name_text);
                       $name->appendChild($namepart);
                       $namepart_attribute = $mods->createAttribute('type');
                       $namepart_attribute->value = 'given';
                       $namepart->appendChild($namepart_attribute);
-                      if (!is_null($person_part->firstChild)) {
-                        $given_name_part = $mods->importNode($person_part->firstChild);
-                        $namepart->appendChild($given_name_part);
-                      }
                       break;
 
                     case 'surname':
-                      $namepart = $mods->createElement('namePart');
+                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                      $namepart = $mods->createElement('namePart', $name_text);
                       $name->appendChild($namepart);
                       $namepart_attribute = $mods->createAttribute('type');
                       $namepart_attribute->value = 'family';
                       $namepart->appendChild($namepart_attribute);
-                      if (!is_null($person_part->firstChild)) {
-                        $surname_part = $mods->importNode($person_part->firstChild);
-                        $namepart->appendChild($surname_part);
-                      }
                       break;
 
                     case 'suffix':
-                      $terms_of_address = $mods->createElement('namePart');
+                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                      $terms_of_address = $mods->createElement('namePart', $name_text);
                       $name->appendChild($terms_of_address);
-                      if (!is_null($person_part->firstChild)) {
-                        $terms_of_address_text = $mods->importNode($person_part->firstChild);
-                        $terms_of_address->appendChild($terms_of_address_text);
-                      }
                       $terms_of_address_attribute = $mods->createAttribute('type');
                       $terms_of_address_attribute->value = 'termsOfAddress';
                       $terms_of_address->appendChild($terms_of_address_attribute);
                       break;
 
                     case 'affiliation':
-                      $affiliation = $mods->createElement('affiliation');
+                      $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                      $affiliation = $mods->createElement('affiliation', $name_text);
                       $name->appendChild($affiliation);
-                      if (!is_null($person_part->firstChild)) {
-                        $affiliation_text = $mods->importNode($person_part->firstChild);
-                        $affiliation->appendChild($affiliation_text);
-                      }
                       break;
                   }
                 }
@@ -436,10 +407,9 @@ function islandora_doi_crossref_translator($crossref_data) {
                     case 'contributor_role':
                       $role = $mods->createElement('role');
                       $name->appendChild($role);
-                      $roleterm = $mods->createElement('roleTerm');
+                      $roleterm_text = strtolower(islandora_doi_filter_html($att->nodeValue));
+                      $roleterm = $mods->createElement('roleTerm', $roleterm_text);
                       $role->appendChild($roleterm);
-                      $roleterm_text = $mods->createTextNode(strtolower($att->nodeValue));
-                      $roleterm->appendChild($roleterm_text);
 
                       $roles = array('author', 'editor', 'translator');
                       if (in_array(strtolower($att->nodeValue), $roles)) {
@@ -470,15 +440,15 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($child->childNodes as $date_part) {
                   switch ($date_part->nodeName) {
                     case 'month':
-                      $pubdate_month = $date_part->nodeValue;
+                      $pubdate_month = islandora_doi_filter_html($date_part->nodeValue);
                       break;
 
                     case 'year':
-                      $pubdate_year = $date_part->nodeValue;
+                      $pubdate_year = islandora_doi_filter_html($date_part->nodeValue);
                       break;
 
                     case 'day':
-                      $pubdate_day = $date_part->nodeValue;
+                      $pubdate_day = islandora_doi_filter_html($date_part->nodeValue);
                       break;
                   }
                 }
@@ -525,25 +495,23 @@ function islandora_doi_crossref_translator($crossref_data) {
                   switch ($identifier->nodeName) {
                     case 'doi':
                       if (!is_null($identifier->firstChild)) {
-                        $doi = $mods->createElement('identifier');
+                        $doi_text = islandora_doi_filter_html($identifier->firstChild);
+                        $doi = $mods->createElement('identifier', $doi_text);
                         $mods->firstChild->appendChild($doi);
                         $doi_attribute = $mods->createAttribute('type');
                         $doi_attribute->value = 'doi';
                         $doi->appendChild($doi_attribute);
-                        $doi_text = $mods->importNode($identifier->firstChild);
-                        $doi->appendChild($doi_text);
                       }
                       break;
 
                     case 'resource':
                       if (!is_null($identifier->firstChild)) {
-                        $uri = $mods->createElement('identifier');
+                        $uri_text = islandora_doi_filter_html($identifier->firstChild);
+                        $uri = $mods->createElement('identifier', $uri_text);
                         $mods->firstChild->appendChild($uri);
                         $uri_attribute = $mods->createAttribute('type');
                         $uri_attribute->value = 'uri';
                         $uri->appendChild($uri_attribute);
-                        $uri_text = $mods->importNode($identifier->firstChild);
-                        $uri->appendChild($uri_text);
                       }
                       break;
                   }
@@ -869,34 +837,28 @@ function islandora_doi_get_mods($id) {
 /**
  * Filter HTML tags from imported XML metadata.
  *
- * @param DOMDocument $doi_domdoc
- *   DOMDocument representing the DOI metadata returned from Crossref
- *
- * @param DOMElement $doi_child_node
- *   DOMElement representing a node of the $doi_domdoc being iterated through
- *
- * @param string $element_name
- *   The name of the element being stripped and rebuilt (optional)
+ * @param string $text
+ *   The text of the metadata to be filtered 
+ * @param array $removals
+ *   An array of strings to be removed from $text prior to filtering
  *
  * @return string 
  *   String filtered using value of $islandora_doi_handle_improted_metadata 
  */
-function islandora_doi_filter_html($doi_domdoc, $doi_child_node, $element_name = FALSE) {
-  $element_text = $doi_domdoc->saveXML($doi_child_node);
-  $element_text = preg_replace('/\s+/', ' ', $element_text);
-
-  if ($element_name) {
-    $element_text = str_replace("<{$element_name}>", '', $element_text);
-    $element_text = str_replace("</{$element_name}>", '', $element_text);
+function islandora_doi_filter_html($text, $removals = FALSE) {
+  if ($removals) {
+    foreach ($removals as $removal) {
+      $text = str_replace($removal, '', $text);
+    }
   }
 
   switch (variable_get('islandora_doi_handle_imported_metadata', 'strip')) {
     case 'strip':
-      $element_text = strip_tags($element_text);
+      $text = strip_tags($text);
       break;
 
     case 'encode':
-      $element_text = htmlspecialchars($element_text);
+      $text = htmlspecialchars($text);
       break;
 
     default:
@@ -904,5 +866,5 @@ function islandora_doi_filter_html($doi_domdoc, $doi_child_node, $element_name =
 
   }
 
-  return $element_text;
+  return $text;
 }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -319,7 +319,7 @@ function islandora_doi_crossref_translator($crossref_data) {
               foreach ($child->childNodes as $grandchild) {
                 switch ($grandchild->nodeName) {
                   case 'title':
-                    $article_title = $mods->importNode($grandchild, TRUE);
+                    $article_title = islandora_doi_create_html_stripped_element($mods, $crossref_xml, $grandchild, "title");
                     $titleinfo->appendChild($article_title);
                     break;
 
@@ -863,4 +863,33 @@ function islandora_doi_get_mods($id) {
   list($source_string, $content_type) = $source_array;
 
   return islandora_doi_translate($source_string, $content_type);
+}
+
+/**
+ * Strip HTML tags from imported XML metadata.
+ *
+ * @param DOMDocument $mods_domdoc
+ *   The DOMDocument representing the MODS record being built
+ *
+ * @param DOMDocument $doi_domdoc
+ *   DOMDocument representing the DOI metadata returned from Crossref
+ *
+ * @param DOMElement $doi_child_node
+ *   DOMElement representing a node of the $doi_domdoc being iterated through
+ *
+ * @param string $element_name
+ *   The name of the element being stripped and rebuilt
+ *
+ * @return DOMElement 
+ *   DOMElement newly created for inclusion in $mods_domdoc
+ */
+function islandora_doi_create_html_stripped_element($mods_domdoc, $doi_domdoc, $doi_child_node, $element_name) {
+  $element_text = $doi_domdoc->saveXML($doi_child_node);
+  $element_text = str_replace("<{$element_name}>", '', $element_text);
+  $element_text = str_replace("</{$element_name}>", '', $element_text);
+  $element_text = str_replace('<', '&lt;', $element_text);
+  $element_text = str_replace('>', '&gt;', $element_text);
+  $element_text = preg_replace('/\s+/', ' ', $element_text);
+  $element_node = $mods_domdoc->createElement($element_name, $element_text);
+  return $element_node;
 }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -364,7 +364,7 @@ function islandora_doi_crossref_translator($crossref_data) {
                   $name_attribute = $mods->createAttribute('type');
                   $name_attribute->value = 'corporate';
                   $name->appendChild($name_attribute);
-                  $namepart_text = islandora_doi_filter_html($crossref_xml->saveXML($organization->firstChild));
+                  $namepart_text = islandora_doi_filter_html($organization);
                   $namepart = $mods->createElement('namePart');
                   $name->appendChild($namepart);
                 }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -888,6 +888,7 @@ function islandora_doi_filter_html($node, $action = NULL) {
     if (!$action) {
       $action = variable_get('islandora_doi_handle_imported_metadata', 'strip');
     }
+
     switch ($action) {
       case 'strip':
         $text = strip_tags($text);
@@ -900,8 +901,11 @@ function islandora_doi_filter_html($node, $action = NULL) {
       default:
         drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => $action)), 'error');
         break;
-
     }
+
+    // Double encode ampersands regardless of prior filtering
+    $text = str_replace(' & ', ' &amp; ', $text);
+    $text = str_replace(' &amp; ', ' &amp;amp; ', $text);
   }
 
   return $text;

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -205,7 +205,7 @@ function islandora_doi_crossref_translator($crossref_data) {
             if (!is_null($child->firstChild)) {
               $titleinfo = $mods->createElement('titleInfo');
               $relateditem->appendChild($titleinfo);
-              $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+              $title_text = islandora_doi_filter_html($child);
               $title = $mods->createElement('title', $title_text);
               $titleinfo->appendChild($title);
             }
@@ -218,7 +218,7 @@ function islandora_doi_crossref_translator($crossref_data) {
               $titleinfo_attribute->value = 'abbreviated';
               $titleinfo->appendChild($titleinfo_attribute);
               $relateditem->appendChild($titleinfo);
-              $title_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+              $title_text = islandora_doi_filter_html($child);
               $title = $mods->createElement('title', $title_text);
               $titleinfo->appendChild($title);
             }
@@ -226,7 +226,7 @@ function islandora_doi_crossref_translator($crossref_data) {
 
           case 'issn':
             if (!is_null($child->firstChild)) {
-              $identifier_text = islandora_doi_filter_html($crossref_xml->saveXML($child->firstChild));
+              $identifier_text = islandora_doi_filter_html($child);
               $identifier = $mods->createElement('identifier', $identifier_text);
               $identifier_attribute = $mods->createAttribute('type');
               $identifier_attribute->value = 'issn';
@@ -246,15 +246,15 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($child->childNodes as $date_part) {
                   switch ($date_part->nodeName) {
                     case 'month':
-                      $pubdate_month = islandora_doi_filter_html($date_part->nodeValue);
+                      $pubdate_month = islandora_doi_filter_html($date_part);
                       break;
 
                     case 'year':
-                      $pubdate_year = islandora_doi_filter_html($date_part->nodeValue);
+                      $pubdate_year = islandora_doi_filter_html($date_part);
                       break;
 
                     case 'day':
-                      $pubdate_day = islandora_doi_filter_html($date_part->nodeValue);
+                      $pubdate_day = islandora_doi_filter_html($date_part);
                       break;
                   }
                 }
@@ -317,7 +317,7 @@ function islandora_doi_crossref_translator($crossref_data) {
                 switch ($grandchild->nodeName) {
                   case 'title':
                     if (!is_null($grandchild)) {
-                      $article_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild), array('<title>', '</title>'));
+                      $article_title_text = islandora_doi_filter_html($grandchild);
                       $article_title = $mods->createElement('title', $article_title_text);
                       $titleinfo->appendChild($article_title);
                     }
@@ -325,7 +325,7 @@ function islandora_doi_crossref_translator($crossref_data) {
 
                   case 'subtitle':
                     if (!is_null($grandchild->firstChild)) {
-                      $article_subtitle_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
+                      $article_subtitle_text = islandora_doi_filter_html($grandchild);
                       $article_subtitle = $mods->createElement('subTitle', $article_subtitle_text);
                       $titleinfo->appendChild($article_subtitle);
                     }
@@ -347,7 +347,7 @@ function islandora_doi_crossref_translator($crossref_data) {
                       }
                     }
                     if (!is_null($grandchild->firstChild)) {
-                      $translated_title_text = islandora_doi_filter_html($crossref_xml->saveXML($grandchild->firstChild));
+                      $translated_title_text = islandora_doi_filter_html($grandchild);
                       $translated_title = $mods->createElement('title', $translated_title_text);
                       $translated_titleinfo->appendChild($translated_title);
                     }
@@ -381,7 +381,7 @@ function islandora_doi_crossref_translator($crossref_data) {
                   switch ($person_part->nodeName) {
                     case 'given_name':
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $name_text = islandora_doi_filter_html($person_part);
                         $namepart = $mods->createElement('namePart', $name_text);
                         $name->appendChild($namepart);
                         $namepart_attribute = $mods->createAttribute('type');
@@ -392,7 +392,7 @@ function islandora_doi_crossref_translator($crossref_data) {
 
                     case 'surname':
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $name_text = islandora_doi_filter_html($person_part);
                         $namepart = $mods->createElement('namePart', $name_text);
                         $name->appendChild($namepart);
                         $namepart_attribute = $mods->createAttribute('type');
@@ -403,7 +403,7 @@ function islandora_doi_crossref_translator($crossref_data) {
 
                     case 'suffix':
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $name_text = islandora_doi_filter_html($person_part);
                         $terms_of_address = $mods->createElement('namePart', $name_text);
                         $name->appendChild($terms_of_address);
                         $terms_of_address_attribute = $mods->createAttribute('type');
@@ -414,7 +414,7 @@ function islandora_doi_crossref_translator($crossref_data) {
 
                     case 'affiliation':
                       if (!is_null($person_part->firstChild)) {
-                        $name_text = islandora_doi_filter_html($crossref_xml->saveXML($person_part->firstChild));
+                        $name_text = islandora_doi_filter_html($person_part);
                         $affiliation = $mods->createElement('affiliation', $name_text);
                         $name->appendChild($affiliation);
                       }
@@ -427,7 +427,7 @@ function islandora_doi_crossref_translator($crossref_data) {
                     case 'contributor_role':
                       $role = $mods->createElement('role');
                       $name->appendChild($role);
-                      $roleterm_text = strtolower(islandora_doi_filter_html($att->nodeValue));
+                      $roleterm_text = strtolower(islandora_doi_filter_html($att));
                       $roleterm = $mods->createElement('roleTerm', $roleterm_text);
                       $role->appendChild($roleterm);
 
@@ -460,15 +460,15 @@ function islandora_doi_crossref_translator($crossref_data) {
                 foreach ($child->childNodes as $date_part) {
                   switch ($date_part->nodeName) {
                     case 'month':
-                      $pubdate_month = islandora_doi_filter_html($date_part->nodeValue);
+                      $pubdate_month = islandora_doi_filter_html($date_part);
                       break;
 
                     case 'year':
-                      $pubdate_year = islandora_doi_filter_html($date_part->nodeValue);
+                      $pubdate_year = islandora_doi_filter_html($date_part);
                       break;
 
                     case 'day':
-                      $pubdate_day = islandora_doi_filter_html($date_part->nodeValue);
+                      $pubdate_day = islandora_doi_filter_html($date_part);
                       break;
                   }
                 }
@@ -515,7 +515,7 @@ function islandora_doi_crossref_translator($crossref_data) {
                   switch ($identifier->nodeName) {
                     case 'doi':
                       if (!is_null($identifier->firstChild)) {
-                        $doi_text = islandora_doi_filter_html($identifier->firstChild);
+                        $doi_text = islandora_doi_filter_html($identifier);
                         $doi = $mods->createElement('identifier', $doi_text);
                         $mods->firstChild->appendChild($doi);
                         $doi_attribute = $mods->createAttribute('type');
@@ -526,7 +526,7 @@ function islandora_doi_crossref_translator($crossref_data) {
 
                     case 'resource':
                       if (!is_null($identifier->firstChild)) {
-                        $uri_text = islandora_doi_filter_html($identifier->firstChild);
+                        $uri_text = islandora_doi_filter_html($identifier);
                         $uri = $mods->createElement('identifier', $uri_text);
                         $mods->firstChild->appendChild($uri);
                         $uri_attribute = $mods->createAttribute('type');
@@ -632,7 +632,6 @@ function islandora_doi_crossref_translator($crossref_data) {
     // Return after first instance.
     return $mods;
   }
-
   return FALSE;
 }
 
@@ -842,7 +841,7 @@ function islandora_doi_get_source($id) {
  *
  * @return DOMDocument|bool
  *   A DOMDocument containing a MODS document, or FALSE if either an error
- *   occured or nothing could be transformed.
+ *   occurred or nothing could be transformed.
  */
 function islandora_doi_get_mods($id) {
   $source_array = islandora_doi_get_source($id);
@@ -857,27 +856,29 @@ function islandora_doi_get_mods($id) {
 /**
  * Filter HTML tags from imported XML metadata.
  *
- * @param string $text
- *   The text of the metadata to be filtered 
- *
- * @param array $removals
- *   An array of strings to be removed from $text prior to filtering
+ * @param DOMNode $node
+ *   The node containing metadata that should be converted into a string,
+ *   possibly containing markup.
  *
  * @return string 
- *   String filtered using value of $islandora_doi_handle_improted_metadata 
+ *   The node's inner content with markup escaped or stripped.
  */
-function islandora_doi_filter_html($text, $removals = FALSE) {
-  if (!$text) {
-    $text = "";
+function islandora_doi_filter_html($node, $action = NULL) {
+  if (!$node) {
+    return "";
   }
   else {
-    if ($removals) {
-      foreach ($removals as $removal) {
-        $text = str_replace($removal, '', $text);
-      }
+    $text  = '';
+    foreach ($node->childNodes as $child) {
+      $text .= $child->ownerDocument->saveXML($child);
     }
 
-    switch (variable_get('islandora_doi_handle_imported_metadata', 'strip')) {
+    $text = preg_replace('/\n\s+/', ' ', $text);
+
+    if (!$action) {
+      $action = variable_get('islandora_doi_handle_imported_metadata', 'strip');
+    }
+    switch ($action) {
       case 'strip':
         $text = strip_tags($text);
         break;
@@ -887,7 +888,7 @@ function islandora_doi_filter_html($text, $removals = FALSE) {
         break;
 
       default:
-        drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => variable_get('islandora_doi_handle_imported_metadata', 'strip'))), 'error');
+        drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => $action)), 'error');
         break;
 
     }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -319,7 +319,8 @@ function islandora_doi_crossref_translator($crossref_data) {
               foreach ($child->childNodes as $grandchild) {
                 switch ($grandchild->nodeName) {
                   case 'title':
-                    $article_title = islandora_doi_create_html_stripped_element($mods, $crossref_xml, $grandchild, "title");
+                    $article_title_text = islandora_doi_filter_html($crossref_xml, $grandchild, "title");
+                    $article_title = $mods->createElement('title', $article_title_text);
                     $titleinfo->appendChild($article_title);
                     break;
 
@@ -866,10 +867,7 @@ function islandora_doi_get_mods($id) {
 }
 
 /**
- * Strip HTML tags from imported XML metadata.
- *
- * @param DOMDocument $mods_domdoc
- *   The DOMDocument representing the MODS record being built
+ * Filter HTML tags from imported XML metadata.
  *
  * @param DOMDocument $doi_domdoc
  *   DOMDocument representing the DOI metadata returned from Crossref
@@ -878,18 +876,27 @@ function islandora_doi_get_mods($id) {
  *   DOMElement representing a node of the $doi_domdoc being iterated through
  *
  * @param string $element_name
- *   The name of the element being stripped and rebuilt
+ *   The name of the element being stripped and rebuilt (optional)
  *
- * @return DOMElement 
- *   DOMElement newly created for inclusion in $mods_domdoc
+ * @return string 
+ *   String filtered according to value of $islandora_doi_handle_improted_metadata 
  */
-function islandora_doi_create_html_stripped_element($mods_domdoc, $doi_domdoc, $doi_child_node, $element_name) {
+function islandora_doi_filter_html($doi_domdoc, $doi_child_node, $element_name = FALSE) {
   $element_text = $doi_domdoc->saveXML($doi_child_node);
-  $element_text = str_replace("<{$element_name}>", '', $element_text);
-  $element_text = str_replace("</{$element_name}>", '', $element_text);
-  $element_text = str_replace('<', '&lt;', $element_text);
-  $element_text = str_replace('>', '&gt;', $element_text);
   $element_text = preg_replace('/\s+/', ' ', $element_text);
-  $element_node = $mods_domdoc->createElement($element_name, $element_text);
-  return $element_node;
+  if ($element_name) {
+    $element_text = str_replace("<{$element_name}>", '', $element_text);
+    $element_text = str_replace("</{$element_name}>", '', $element_text);
+  }
+  switch (variable_get('islandora_doi_handle_imported_metadata')) {
+    case 'strip':
+      $element_text = strip_tags($element_text);
+      break;
+    case 'encode':
+      $element_text = htmlspecialchars($element_text);
+      break;
+    default:
+      break;
+  }
+  return $element_text;
 }

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -319,7 +319,7 @@ function islandora_doi_crossref_translator($crossref_data) {
               foreach ($child->childNodes as $grandchild) {
                 switch ($grandchild->nodeName) {
                   case 'title':
-                    if (!is_null($grandchild)) {
+                    if (!is_null($grandchild->firstChild)) {
                       $article_title_text = islandora_doi_filter_html($grandchild);
                       $article_title = $mods->createElement('title', $article_title_text);
                       $titleinfo->appendChild($article_title);
@@ -895,17 +895,13 @@ function islandora_doi_filter_html($node, $action = NULL) {
         break;
 
       case 'encode':
-        $text = htmlspecialchars($text);
+        $text = htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8', FALSE);
         break;
 
       default:
         drupal_set_message(t('@var is not a recognized option for handling HTML in imported DOI metadata.', array('@var' => $action)), 'error');
         break;
     }
-
-    // Double encode ampersands regardless of prior filtering
-    $text = str_replace(' & ', ' &amp; ', $text);
-    $text = str_replace(' &amp; ', ' &amp;amp; ', $text);
   }
 
   return $text;

--- a/modules/doi/includes/utilities.inc
+++ b/modules/doi/includes/utilities.inc
@@ -879,24 +879,30 @@ function islandora_doi_get_mods($id) {
  *   The name of the element being stripped and rebuilt (optional)
  *
  * @return string 
- *   String filtered according to value of $islandora_doi_handle_improted_metadata 
+ *   String filtered using value of $islandora_doi_handle_improted_metadata 
  */
 function islandora_doi_filter_html($doi_domdoc, $doi_child_node, $element_name = FALSE) {
   $element_text = $doi_domdoc->saveXML($doi_child_node);
   $element_text = preg_replace('/\s+/', ' ', $element_text);
+
   if ($element_name) {
     $element_text = str_replace("<{$element_name}>", '', $element_text);
     $element_text = str_replace("</{$element_name}>", '', $element_text);
   }
+
   switch (variable_get('islandora_doi_handle_imported_metadata', 'strip')) {
     case 'strip':
       $element_text = strip_tags($element_text);
       break;
+
     case 'encode':
       $element_text = htmlspecialchars($element_text);
       break;
+
     default:
       break;
+
   }
+
   return $element_text;
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2185

# What does this Pull Request do?
- Adds a function to the bottom of islandora_scholar/modules/doi/includes/utilities.inc that replaces brackets in imported DOI metadata with entity references to eliminate importing subelements that break MODS validation.
- Uses new function on title importing

# How should this be tested?
Use the DOI importer on DOIs with problematic metadata, such as:
- 10.1021/ed300689n
- 10.1080/10826070600757680

# Additional Notes:
This was originally figured out by Gail Lewis at FALSC, so all glory to her. I just turned it into a function that could be used on other elements as well.

# Interested parties
@willtp87 @rosiel @DiegoPino