### PR TITLE
Fixing Scholar Embargoes menus so they appear in the right place

### DIFF
--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -34,7 +34,7 @@ function islandora_scholar_embargo_menu() {
     'access arguments' => array(ISLANDORA_SCHOLAR_EMBARGO_CAN_EMBARGO_ANY),
     'file' => 'includes/admin.form.inc',
   );
-  $items['admin/islandora/solution_pack_config/embargo/settings'] = array(
+  $items['admin/islandora/tools/embargo/settings'] = array(
     'title' => 'Embargo settings',
     'description' => 'Configure the Embargo module.',
     'page callback' => 'drupal_get_form',
@@ -43,7 +43,7 @@ function islandora_scholar_embargo_menu() {
     'file' => 'includes/admin.form.inc',
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
-  $items['admin/islandora/solution_pack_config/embargo/list'] = array(
+  $items['admin/islandora/tools/embargo/list'] = array(
     'title' => 'Manage Embargoed Items',
     'file' => 'includes/embargo_manage.inc',
     'page callback' => 'drupal_get_form',
@@ -51,7 +51,7 @@ function islandora_scholar_embargo_menu() {
     'type' => MENU_LOCAL_TASK,
     'access arguments' => array(ISLANDORA_SCHOLAR_EMBARGO_CAN_EMBARGO_ANY),
   );
-  $items['admin/islandora/solution_pack_config/embargo/roles'] = array(
+  $items['admin/islandora/tools/embargo/roles'] = array(
     'title' => 'Manage Embargo Roles',
     'file' => 'includes/embargo_roles_manage.inc',
     'page callback' => 'drupal_get_form',


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1284

# What does this Pull Request do?
Moves the Scholar Embargo admin menu subtabs.

# What's new?
When I originally moved the Scholar Embargo menu from "Solution Pack Config" to "Tools", I only moved the top level menu item; the routes for the subtabs didn't get updated so they weren't available in the new menu location. This PR fixes that.

# How should this be tested?
Load up a VM with current Scholar, go to the Scholar Embargoes admin menu under "Tools" and see that the subtabs aren't there. Load this PR, clear the cache, and then they will be.


# Additional Notes:
Many thanks to @racheljsmart for finding this error! :1st_place_medal: :100: :+1: 

# Interested parties
@DiegoPino @rosiel 
