### PR TITLE
Citeproc V2 fix

### DIFF
--- a/modules/citeproc/includes/admin.form.inc
+++ b/modules/citeproc/includes/admin.form.inc
@@ -23,7 +23,7 @@ function citeproc_admin_form() {
   $form['citeproc_backend'] = array(
     '#type' => 'radios',
     '#title' => t('What version of citeproc library should be used?'),
-    '#default_value' => variable_get('citeproc_backend', citeproc_default_backend()),
+    '#default_value' => variable_get('citeproc_backend'),
     '#options' => $options,
     '#description' => t('V2 of citeproc-php is recommended when your PHP version supports it.'),
   );

--- a/modules/citeproc/includes/admin.form.inc
+++ b/modules/citeproc/includes/admin.form.inc
@@ -23,7 +23,7 @@ function citeproc_admin_form() {
   $form['citeproc_backend'] = array(
     '#type' => 'radios',
     '#title' => t('What version of citeproc library should be used?'),
-    '#default_value' => variable_get('citeproc_backend'),
+    '#default_value' => variable_get('citeproc_backend', citeproc_v2_supported() ? CITEPROC_BACKEND_V2 : CITEPROC_BACKEND_V1),
     '#options' => $options,
     '#description' => t('V2 of citeproc-php is recommended when your PHP version supports it.'),
   );


### PR DESCRIPTION
## What does this Pull Request do?

During code review of https://github.com/Islandora/islandora_scholar/pull/291 a function as removed. One reference to this function remains in the module, and it prevents the admin form from loading, if the variable isn't set.

It should be set since it gets set in hook_init and hook_install, but it is possible to load the form with the variable not set and get an error.

## How should this be tested?

* Make sure variable isn't set, load form, see error. 
* Apply patch, load form, no error.

## Interested parties
@DiegoPino 