### PR TITLE
Work on ISLANDORA-2278 - Remove Islandora Scholar as a .info dependen…

### DIFF
--- a/modules/islandora_scholar_embargo/README.md
+++ b/modules/islandora_scholar_embargo/README.md
@@ -10,6 +10,7 @@ The following Drupal modules are required:
 
  * [Islandora](https://github.com/islandora/islandora)
  * [Islandora_Scholar](https://github.com/islandora/islandora_scholar)
+   * Islandora Scholar does not need to be enabled to run this module, but it must be installed in order to preserve Scholar Embargo's location in the `modules` directory.
  * [Islandora XACML API](https://github.com/islandora/islandora_xacml_editor/tree/7.x/api)
  * [Rules](https://www.drupal.org/project/rules)
 

--- a/modules/islandora_scholar_embargo/includes/admin.form.inc
+++ b/modules/islandora_scholar_embargo/includes/admin.form.inc
@@ -19,7 +19,12 @@
 function islandora_embargo_admin(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $options = islandora_get_content_models();
-  $selected = variable_get('islandora_embargo_content_models', array('ir:citationCModel', 'ir:thesisCModel'));
+  if (module_exists('islandora_scholar')) {
+    $selected = variable_get('islandora_embargo_content_models', array('ir:citationCModel', 'ir:thesisCModel'));
+  }
+  else {
+    $selected = variable_get('islandora_embargo_content_models', array());
+  }
   foreach ($selected as $cmodel) {
     if (isset($options[$cmodel])) {
       $options = array($cmodel => $options[$cmodel]) + $options;

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.info
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.info
@@ -4,7 +4,6 @@ configure = admin/islandora/solution_pack_config/embargo
 package = Islandora Solution Packs
 dependencies[] = rules
 dependencies[] = islandora
-dependencies[] = islandora_scholar
 dependencies[] = islandora_xacml_api
 core = 7.x
 version = 7.x-dev


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2278

# What does this Pull Request do?

Removes Islandora Scholar as a .info dependency from Scholar Embargo

# What's new?

This PR removes `dependencies[] = islandora_scholar` from islandora_scholar_embargo.info, allowing site admins to not have to run the full scholar suite to use the Scholar Embargo module. Islandora Scholar must remain installed, but it and the other members of that group need not be enabled to use Scholar Embargo.

It also updates Scholar Embargo's README to indicate that the main Scholar module is no longer an hard dependency.

# How should this be tested?

1. enable a content model that can have embargos, other than Citation and Thesis, at admin/islandora/tools/embargo
1. on an object of the newly added content model, set an embargo, e.g. using tomorrow's date
1. in a private browser window, visit the object. You should get an Access denied message.
1. check out the [7.x-ISLANDORA-2278 branch](https://github.com/mjordan/islandora_scholar/tree/7.x-ISLANDORA-2278).
1. disable the Islandora Scholar group of modules by running `drush dis -y islandora_scholar`. "islandora_scholar_embargo" will not be in the list of modules disabled.
1. check Scholar Embargo's list of embargoed objects at `admin/islandora/tools/embargo/list`. Your test object should be in this list.
1. revisit your test object. You should still get the Access denied message.


# Additional Notes:

* Does this change require documentation to be updated?

Yes, https://wiki.duraspace.org/display/ISLANDORA/Islandora+Scholar#IslandoraScholar-ScholarEmbargo.

* Does this change add any new dependencies? 

No.

* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 

No.

* Could this change impact execution of existing code?

No, it should not.

# Interested parties
Tagging @bryjbrown.
