### PR TITLE
ISLANDORA-2307 Make submodules' admin pages show up as tabs.

### DIFF
--- a/modules/bibutils/bibutils.module
+++ b/modules/bibutils/bibutils.module
@@ -30,7 +30,7 @@ function bibutils_menu() {
     'page arguments' => array('bibutils_admin_form'),
     'access arguments' => array('administer site configuration'),
     'file' => 'includes/admin.form.inc',
-    'type' => MENU_NORMAL_ITEM,
+    'type' => MENU_LOCAL_TASK,
   );
 
   return $items;

--- a/modules/bibutils/includes/utilities.inc
+++ b/modules/bibutils/includes/utilities.inc
@@ -101,7 +101,7 @@ class Bibutils {
   }
 
   /**
-   * Executes the given command and the exit status and output of the command.
+   * Executes the given command and returns the exit status and output.
    *
    * @param string $command
    *   The command to execute.

--- a/modules/citeproc/citeproc.module
+++ b/modules/citeproc/citeproc.module
@@ -34,7 +34,7 @@ function citeproc_menu() {
     'page arguments' => array('citeproc_admin_form'),
     'access arguments' => array('administer site configuration'),
     'file' => 'includes/admin.form.inc',
-    'type' => MENU_NORMAL_ITEM,
+    'type' => MENU_LOCAL_TASK,
   );
   return $items;
 }


### PR DESCRIPTION
**JIRA Ticket**:  https://jira.duraspace.org/browse/ISLANDORA-2307

# What does this Pull Request do?

Puts "Citeproc" and "Bibutils" tabs in the Scholar admin menu. 

# What's new?

Use MENU_LOCAL_TASK instead of MENU_NORMAL_ITEM.

Also fixes a typo.

# How should this be tested?

Load http://localhost:8000/admin/islandora/solution_pack_config/scholar
Without this PR: you are missing tabs to two admin pages!
With this PR: You see tabs for the citeproc and bibutils pages.

# Additional Notes:

Example:
* Does this change require documentation to be updated? - yes! Screenshots in the wiki, and the options should get explained!  
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
