### PR TITLE
ISLANDORA-2027: Implements Gail Lewis fix for namespace filtering on scholar embargoes

### DIFF
--- a/modules/islandora_scholar_embargo/includes/embargo.inc
+++ b/modules/islandora_scholar_embargo/includes/embargo.inc
@@ -460,6 +460,7 @@ SELECT ?obj ?date
 FROM <#ri>
 WHERE {
   ?obj is:embargo-until ?date
+  !namespace_filter
 }
 EOQ;
   if ($count) {
@@ -467,6 +468,10 @@ EOQ;
 ORDER BY ?obj
 EOQ;
   }
+  $namespace_filter = islandora_scholar_embargo_get_namespace_filters();
+  $current_embargo = format_string($current_embargo, array(
+    '!namespace_filter' => !empty($namespace_filter) ? $namespace_filter : '',
+  ));
   $connection = islandora_get_tuque_connection();
   $ri = $connection->repository->ri;
   return $count ? $ri->countQuery($current_embargo, 'sparql') : $ri->sparqlQuery($current_embargo, 'unlimited', '0');
@@ -506,13 +511,35 @@ EOQ;
     $current_embargo .= "FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?obj) > xs:string('info:fedora/{$slice_params['offset_pid']}')))";
   }
   $current_embargo .= <<<EOQ
+  !namespace_filter
 }
 ORDER BY ASC(?date) ASC(?obj)
 EOQ;
+  $namespace_filter = islandora_scholar_embargo_get_namespace_filters();
+  $current_embargo = format_string($current_embargo, array(
+    '!namespace_filter' => !empty($namespace_filter) ? $namespace_filter : '',
+  ));
 
   // Use the query.
   $connection = islandora_get_tuque_connection();
   return $connection->repository->ri->sparqlQuery($current_embargo, $limit);
+}
+
+/**
+ * Implements islandora_scholar_embargo_get_namespace_filters().
+ */
+function islandora_scholar_embargo_get_namespace_filters() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $enforced = variable_get('islandora_namespace_restriction_enforced', FALSE);
+  if ($enforced) {
+    $namespace_array = islandora_get_allowed_namespaces();
+    $namespace_sparql = implode('|', $namespace_array);
+    $filter = format_string('regex(str(?obj), "info:fedora/(!namespaces):")', array('!namespaces' => $namespace_sparql));
+    if (!empty($filter)) {
+      return "FILTER($filter)";
+    }
+  }
+  return '';
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2027

# What does this Pull Request do?
Copy/pastes @glewisorg's solution to applying namespace filtering to the SPARQL queries asking for all embargoed objects

# What's new?
Adds code from https://github.com/FLVC/islandora_scholar/tree/flvc to the core 7.x branch so that everyone can filter out embargoed items that are outside of a multisite's allowed namespaces the same way FL-Islandora can.

Use case: you are running a multisite where individual sites are minting new PIDs in their own namespace, and they are all using Islandora Scholar Embargo. Currently, the SPARQL query that retrieves all embargoed items doesn't filter out restricted namespaces, so site A will see site B's embargoed items under `/admin/islandora/tools/embargo/list`, even though site B's namespace is not listed in site A's allowed namespaces (`/admin/islandora/configure`).

With this PR, the SPARQL query will filter out all the embargoed items outside of a site's allowed namespace.

# How should this be tested?
1. Spin up a fresh VM and set the Islandora Scholar module's branch to 7.x
2. Go to a folder and create a new object in the default namespace (for example, "nsa")
3. Go to the collection management tab for the parent collection, and set a brand new namespace to be the default for that same object type (for example, "nsb")
4. Create a new object of the same type so that it has the new namespace
5. Apply embargoes to both objects
6. Go to `/admin/islandora/tools/embargo/list` and verify that both objects are visible
7. Go to `/admin/islandora/configure` and click the "Namespaces", and check "Enforce namespace restrictions", and add make sure the first object's namespace is on the list of allowed namespaces, but the second object's namespace is not
8. Go back to the original collection that both objects are in, and verify that the second object no longer appears (Islandora is filtering it out)
9. Go back to `/admin/islandora/tools/embargo/list` and verify that, despite Islandora filtering out the second object's namespace, the second object is still appearing in the list of embargoed objects
10. Switch the Islandora Scholar module's branch to this PR, and run `drush cc all`
11. Refresh `/admin/islandora/tools/embargo/list` and verify that the second object with the disallowed namespace no longer appears in the list of embargoed items.

# Additional Notes:
Many thanks to @glewisorg for the solution. I am but a humble copy/paster of her original efforts.

# Interested parties
@Islandora/7-x-1-x-committers @bondjimbond @DonRichards @DiegoPino @rosiel 