### PR TITLE
Removes line making Google Scholar link checkbox required

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -61,7 +61,6 @@ function islandora_scholar_admin_form() {
     '#type' => 'checkbox',
     '#title' => t('Render Google Scholar Search link'),
     '#description' => t('Enable Searching in Google Scholar.'),
-    '#required' => TRUE,
   ));
   $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_primary_search_xpath', '//mods:mods[1]/mods:identifier[@type="doi"]', array(
     '#type' => 'textfield',


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2313

# What does this Pull Request do?
Deletes the line that makes "Render Google Scholar search links" in the Scholar admin config menu required.

Now the config page can be saved without having that checkbox checked.

# How should this be tested?
Load up the 7.x branch in a VM and try to save the Scholar admin config page with the checkbox unchecked. It won't let you. Switch to this PR and clear the cache, and now you can.

# Interested parties
@Islandora/7-x-1-x-committers @bondjimbond @DonRichards 
