### PR TITLE
Removes PDF Download link from citation/thesis template for PDF.js viewer

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -151,7 +151,9 @@ function islandora_scholar_get_view(AbstractObject $object) {
     }
   }
 
-  if (isset($object['PDF']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PDF'])) {
+  $default_viewer = variable_get('islandora_scholar_viewers');
+  $default_viewer = $default_viewer['default'];
+  if (isset($object['PDF']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PDF']) && $default_viewer == 'none') {
     $filename = str_replace(":", "_", $object->id);
     $display['pdf_download'] = array(
       '#type' => 'item',


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2291

# What does this Pull Request do?
Makes citation/thesis template display more consistent with the PDF template by removing the redundant PDF Download link if using PDF.js viewer.

# What's new?
Adds a check to make sure that the variable `islandora_scholar_viewer` is using the default viewer before adding the PDF Download link. If its not, skip it.

# How should this be tested?
Load up 7.x, create an object, and view it using both the default and PDF.js viewers. Both will have the PDF Download link. Switch to this PR and look at them again. The default viewer will still have the PDF Download link but the PDF.js viewer will not.

# Interested parties
@Islandora/7-x-1-x-committers @DonRichards @bondjimbond 
