### PR TITLE
ISLANDORA-2398: Adds subtitle to citation_title metatag

### DIFF
--- a/modules/islandora_google_scholar/islandora_google_scholar.module
+++ b/modules/islandora_google_scholar/islandora_google_scholar.module
@@ -30,9 +30,16 @@ function islandora_google_scholar_create_meta_tags($object) {
 
     $title_results = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_title', '//mods:mods[1]/mods:titleInfo/mods:title'));
     $title = (string) reset($title_results);
+    $subtitle_results = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_title_sub_title', '//mods:mods[1]/mods:titleInfo/mods:subTitle'));
+    $subtitle = (string) reset($subtitle_results);
 
     if (!empty($title)) {
-      $tags['citation_title'] = $title;
+      if (!empty($subtitle)) {
+        $tags['citation_title'] = "{$title}: {$subtitle}";
+      }
+      else {
+        $tags['citation_title'] = $title;
+      }
     }
     else {
       return FALSE;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2398

# What does this Pull Request do?
Formats citation_title to include MODS subTitle element if available.

# How should this be tested?
Find or create two repository objects, one with no subtitle and one with a subtitle. Check the HTML of both to see that, with the current code, the citation_title metatag is only displaying the MODS title content. Switch to this PR and see that the element with no subtitle stayed the same, but the object with the subtitle now outputs it in the citation_title metatag.

# Interested parties
@Islandora/7-x-1-x-committers
