### PR TITLE
Fix Travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - ln -s $HOME/islandora_bookmark sites/all/modules/islandora_bookmark
   - ln -s $HOME/islandora_batch sites/all/modules/islandora_batch
   - drush cc all
-  - drush -u 1 en --yes islandora_scholar bibutils citation_exporter doi_importer islandora_google_scholar islandora_scholar_embargo islandora_bibliography ris_importer endnotexml_importer pmid_importer citeproc csl
+  - drush -u 1 en --yes islandora_scholar islandora_scholar_embargo bibutils citation_exporter doi_importer islandora_google_scholar islandora_bibliography ris_importer endnotexml_importer pmid_importer citeproc csl
 before_script:
   # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.info
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.info
@@ -2,6 +2,7 @@ name = Islandora Scholar Embargo
 description = Support embargo management in Islandora Scholar.
 configure = admin/islandora/solution_pack_config/embargo
 package = Islandora Solution Packs
+dependencies[] = entity
 dependencies[] = rules
 dependencies[] = islandora
 dependencies[] = islandora_xacml_api


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2390)

# What does this Pull Request do?

Reorders commands in the .travis.yml file and adds "entity" dependency to Islandora Scholar Embargo .info file.

This resolves the problem of Travis failing to build, because the "rules" module (a dependency of some Scholar submodules) requires "entity_token", which is a submodule of "entity", before "entity" itself is downloaded.

# What's new?

Just a change in order, plus making the "entity" dependency of Islandora Scholar Embargo explicit (rather than an invisible dependency-of-a-dependency).

Should not impact anything.

# How should this be tested?

See if Travis builds successfully on this PR.

# Interested parties
@Islandora/7-x-1-x-committers
