### PR TITLE
ISLANDORA-2409: Selectable colorspace for PREVIEW/TN

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -317,6 +317,19 @@ function islandora_scholar_admin_pdf_form($form, &$form_state) {
     '#size' => 5,
   );
 
+  $form['islandora_scholar_thumbnail_fieldset']['islandora_scholar_thumbnail_colorspace'] = array(
+    '#type' => 'select',
+    '#title' => t('Colorspace'),
+    '#options' => array(
+      'sRGB' => t('sRGB'),
+      'RGB' => t('RGB'),
+      'CMYK' => t('CMYK'),
+      'Gray' => t('Grayscale'),
+    ),
+    '#description' => t('The colorspace for the derived thumbnail.'),
+    '#default_value' => variable_get('islandora_scholar_thumbnail_colorspace', 'sRGB'),
+  );
+
   $form['islandora_scholar_preview_fieldset'] = array(
     '#type' => 'fieldset',
     '#title' => t('Preview image'),
@@ -340,6 +353,20 @@ function islandora_scholar_admin_pdf_form($form, &$form_state) {
     '#default_value' => variable_get('islandora_scholar_preview_height', 700),
     '#size' => 5,
   );
+
+  $form['islandora_scholar_preview_fieldset']['islandora_scholar_preview_colorspace'] = array(
+    '#type' => 'select',
+    '#title' => t('Colorspace'),
+    '#options' => array(
+      'sRGB' => t('sRGB'),
+      'RGB' => t('RGB'),
+      'CMYK' => t('CMYK'),
+      'Gray' => t('Grayscale'),
+    ),
+    '#description' => t('The colorspace for the derived preview.'),
+    '#default_value' => variable_get('islandora_scholar_preview_colorspace', 'sRGB'),
+  );
+
   $form['islandora_scholar_preview_fieldset']['islandora_scholar_preview_density'] = array(
     '#type' => 'textfield',
     '#title' => t('Density used to generate preview'),

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -47,7 +47,7 @@ function islandora_scholar_add_tn_derivative(AbstractObject $object, $force = FA
     $height = variable_get('islandora_scholar_thumbnail_height', 200);
     $colorspace = variable_get('islandora_scholar_thumbnail_colorspace', 'sRGB');
     $file_uri = islandora_scholar_get_derivative_source_as_unmanaged_file($object, $hook['source_dsid']);
-    $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $force, $hook['source_dsid']);
+    $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $force, $hook['source_dsid'], $colorspace);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -165,7 +165,7 @@ function islandora_scholar_add_preview_derivative(AbstractObject $object, $force
     $height = variable_get('islandora_scholar_preview_height', 700);
     $colorspace = variable_get('islandora_scholar_preview_colorspace', 'sRGB');
     $file_uri = islandora_scholar_get_derivative_source_as_unmanaged_file($object, $hook['source_dsid']);
-    $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $colorspace, $force, $hook['source_dsid']);
+    $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $force, $hook['source_dsid'], $colorspace);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -184,12 +184,12 @@ function islandora_scholar_add_preview_derivative(AbstractObject $object, $force
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
- * @param string $colorspace
- *   The colorspace for the derived datastream.
  * @param bool $force
  *   Whether the derivative generation is being forced or not.
  * @param string $source_dsid
  *   The source DSID that triggered the derivative creation.
+ * @param string $colorspace
+ *   The colorspace for the derived datastream.
  *
  * @return array|NULL
  *   An array describing the outcome of adding the JPG derivative or NULL if no
@@ -197,7 +197,7 @@ function islandora_scholar_add_preview_derivative(AbstractObject $object, $force
  *
  * @see hook_islandora_derivative()
  */
-function islandora_scholar_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $colorspace, $force, $source_dsid) {
+function islandora_scholar_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $force, $source_dsid, $colorspace = NULL) {
   if (!isset($object[$dsid]) || (isset($object[$dsid]) && $force === TRUE)) {
     if (!isset($object[$source_dsid])) {
       return islandora_scholar_missing_pdf_datastream($object->id);

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -45,6 +45,7 @@ function islandora_scholar_add_tn_derivative(AbstractObject $object, $force = FA
   if ($force || !isset($object['TN'])) {
     $width = variable_get('islandora_scholar_thumbnail_width', 200);
     $height = variable_get('islandora_scholar_thumbnail_height', 200);
+    $colorspace = variable_get('islandora_scholar_thumbnail_colorspace', 'sRGB');
     $file_uri = islandora_scholar_get_derivative_source_as_unmanaged_file($object, $hook['source_dsid']);
     $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'TN', $width, $height, $force, $hook['source_dsid']);
     file_unmanaged_delete($file_uri);
@@ -162,8 +163,9 @@ function islandora_scholar_add_preview_derivative(AbstractObject $object, $force
   if ($force || !isset($object['PREVIEW'])) {
     $width = variable_get('islandora_scholar_preview_width', 500);
     $height = variable_get('islandora_scholar_preview_height', 700);
+    $colorspace = variable_get('islandora_scholar_preview_colorspace', 'sRGB');
     $file_uri = islandora_scholar_get_derivative_source_as_unmanaged_file($object, $hook['source_dsid']);
-    $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $force, $hook['source_dsid']);
+    $results = islandora_scholar_add_jpg_derivative($object, $file_uri, 'PREVIEW', $width, $height, $colorspace, $force, $hook['source_dsid']);
     file_unmanaged_delete($file_uri);
     return $results;
   }
@@ -182,6 +184,8 @@ function islandora_scholar_add_preview_derivative(AbstractObject $object, $force
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
+ * @param string $colorspace
+ *   The colorspace for the derived datastream.
  * @param bool $force
  *   Whether the derivative generation is being forced or not.
  * @param string $source_dsid
@@ -193,12 +197,12 @@ function islandora_scholar_add_preview_derivative(AbstractObject $object, $force
  *
  * @see hook_islandora_derivative()
  */
-function islandora_scholar_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $force, $source_dsid) {
+function islandora_scholar_add_jpg_derivative(AbstractObject $object, $file_uri, $dsid, $width, $height, $colorspace, $force, $source_dsid) {
   if (!isset($object[$dsid]) || (isset($object[$dsid]) && $force === TRUE)) {
     if (!isset($object[$source_dsid])) {
       return islandora_scholar_missing_pdf_datastream($object->id);
     }
-    $derivative_file_uri = islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $height);
+    $derivative_file_uri = islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $height, $colorspace);
     // Receive a valid file URI to add or an error message otherwise.
     if (!is_array($derivative_file_uri) && file_valid_uri($derivative_file_uri)) {
       $success = islandora_scholar_add_datastream($object, $dsid, $derivative_file_uri);
@@ -252,13 +256,21 @@ function islandora_scholar_add_jpg_derivative(AbstractObject $object, $file_uri,
  *   The width to make the derived datastream.
  * @param int $height
  *   The height to make the derived datastream.
+ * @param string $colorspace
+ *   The colorspace for the derived datastream.
  *
  * @return string|array
  *   A URI to the generated derivative if successful, error message otherwise.
  *
  * @see hook_islandora_derivative()
  */
-function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $height) {
+function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $height, $colorspace = NULL) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  if (is_null($colorspace)) {
+    $colorspace = 'sRGB';
+    $message = islandora_deprecated('7.x-1.12', t('The colorspace now needs to be specified in islandora_scholar_create_jpg_derivative'));
+    trigger_error(filter_xss($message), E_USER_DEPRECATED);
+  }
   $source = drupal_realpath($file_uri) . '[0]';
   // Get the base name of the source file.
   $base = pathinfo($source, PATHINFO_FILENAME);
@@ -266,7 +278,7 @@ function islandora_scholar_create_jpg_derivative($file_uri, $dsid, $width, $heig
   $dest = drupal_realpath($temp);
   $args['quality'] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
   $args['previewsize'] = '-resize ' . escapeshellarg("{$width}x{$height}");
-  $args['colors'] = '-colorspace RGB';
+  $args['colors'] = "-colorspace {$colorspace}";
   $args['flatten'] = '-flatten';
   $context = array(
     'source' => $source,

--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -31,9 +31,11 @@ function islandora_scholar_uninstall() {
     'islandora_scholar_romeo_enable',
     'islandora_scholar_thumbnail_width',
     'islandora_scholar_thumbnail_height',
+    'islandora_scholar_thumbnail_colorspace',
     'islandora_scholar_path_to_pdftotext',
     'islandora_scholar_preview_width',
     'islandora_scholar_preview_height',
+    'islandora_scholar_preview_colorspace',
     'islandora_scholar_issn_cache_time',
     'islandora_scholar_romeo_key',
     'islandora_scholar_romeo_url',
@@ -136,4 +138,14 @@ function islandora_scholar_update_7101(&$sandbox) {
  */
 function islandora_scholar_update_7102(&$sandbox) {
   return t('The permission to administer the Islandora Scholar module has been changed to "Administer site configuration"; roles that could previously access Islandora Scholar management pages via the "Use the administration pages and help" permission will no longer be able to do so. Permissions may need to be reviewed.');
+}
+
+/**
+ * Maintain existing RGB colorspace profile configuration.
+ */
+function islandora_scholar_update_7103(&$sandbox) {
+  variable_set('islandora_scholar_preview_colorspace', 'RGB');
+  variable_set('islandora_scholar_thumbnail_colorspace', 'RGB');
+  $t = get_t();
+  return $t('Set colorspace configuration to RBG to maintain existing profile.');
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2409

# What does this Pull Request do?

Adds a dropdown to the solution pack config UI which allows users to select from a list of colorspaces to use when creating TN/PREVIEW derivatives. The intention of this pull is to allow users to choose a more reliable/consistent colorspace profile for PDF derivatives. The currently hardcoded RGB colorspace appears to create substantially darker derivatives compared to their source file.

# What's new?

* Adds dropdown select to configure colorspace configuration for PREVIEW & TN derivative datastreams
* Profiles include RBG, sRGB, CYMK & Grayscale
* Update hook preserves existing colorspace for older systems

# How should this be tested?

Prior to pulling down the changes, ingest a test PDF (preferably a PDF with light colors on the 1st page) and observe that the PREVIEW and TN datastreams colors are far darker than the source PDF's 1st page's colors.

Pull down the changes and go to the PDF scholar solution pack config UI. Confirm the sRGB colorspace is set for both PREVIEW and TN and submit the form. Ingest another test PDF and observe the PREVIEW and TN datastreams and confirm that they are closer to the original source PDF.

# Additional Notes:

Similar pull request for PDF sol pack: https://github.com/Islandora/islandora_solution_pack_pdf/pull/138