### PR TITLE
Enable Islandora Google Scholar on Scholar install and update

### DIFF
--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -13,6 +13,9 @@
 function islandora_scholar_install() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_scholar');
+  $modules = array('islandora_google_scholar');
+  $enable_dependencies = TRUE;
+  module_enable($modules, $enable_dependencies);
 }
 
 /**
@@ -148,4 +151,16 @@ function islandora_scholar_update_7103(&$sandbox) {
   variable_set('islandora_scholar_thumbnail_colorspace', 'RGB');
   $t = get_t();
   return $t('Set colorspace configuration to RBG to maintain existing profile.');
+}
+
+/**
+ * Ensure Islandora Google Scholar is enabled.
+ */
+function islandora_scholar_update_7104(&$sandbox) {
+  if (!module_exists('islandora_google_scholar')) {
+    $modules = array('islandora_google_scholar');
+    $enable_dependencies = TRUE;
+    module_enable($modules, $enable_dependencies);
+    return t('The Islandora Google Scholar module has been enabled by default. If you wish to disable it you may do so at admin/modules.');
+  }
 }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2448)

# What does this Pull Request do?

On installation or update of Islandora Scholar, checks if Islandora Google Scholar is enabled. If not, it does so. (And lets the user know that this happened.)

# What's new?

As described above. The Islandora IR Interest Group expressed a desire to default to turning on Islandora Google Scholar, rather than relying on people reading the documentation and realizing that they should turn on the module. Not having it turned on means Google Scholar will probably not index this content.

# How should this be tested?

- If Islandora Google Scholar is enabled, disable it
- Pull this PR and run update.php
- See message, confirm that Islandora Google Scholar now enabled.
- Disable Islandora Scholar and everything that relates to it.
- Enable it again.
- Check whether Islandora Google Scholar is enabled.

# Interested parties
@Islandora/7-x-1-x-committers @bryjbrown 
