### PR TITLE
Include Google Scholar's required aggregation pages out-of-the-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,31 @@ These XPaths are shared within most of the submodules. To see the MODS value aft
   * Default Value: //mods:mods[1]/mods:recordInfo/mods:recordCreationDate
   * XPath to use for the online_date.
 
+
+- __Google Scholar Publication Date SOLR Field__
+  * The solr date field used to facet by publication date during Google Scholar indexing. This is an autocomplete field. Start typing the solr field name and then select from the list. *Be sure to select a field ending with "_dt" or "_mdt", otherwise solr errors will result during google indexing.*
+  * Defaults value: `mods_originInfo_dateIssued_mdt`
+
+
+- __Google Scholar Abstract SOLR Field__
+  * This is used when displaying object abstracts as required by Google Scholar.
+  * Defaults value: `mods_abstract_ms`
+
+
+- __Excluded Content Models__
+  * Enter a comma-separated list of content model PIDs to exclude from Google Scholar search indexing. For example: `islandora:collectionCModel, islandora:newspaperCModel`
+  * Defaults to: `islandora:collectionCModel`
+
+
+- __Additional Google Scholar Configuration Notes__
+  * The islandora_google_scholar module exposes several pages to facilitate Google Scholar indexing of your repository. Urls to these pages should be entered into your [Google Scholar Inclusions dashboard](https://partnerdash.google.com/partnerdash/d/scholarinclusions).
+  * **Year index:** "Please provide the URL of a page listing all years available."
+    * Path: /gs_years, e.g, http://repository.example.edu/gs_years
+  * **List of articles for each year:** "Please provide examples of URLs to pages that provide a list of articles for a given year."
+    * Path: /gs_year/[YYYY], e.g. http://repository.example.edu/gs_year/1850
+  * **Abstract examples:** "Please provide examples of individual abstract pages."
+    * Path: /gs_abstract/[PID], e.g. http://repository.example.edu/gs_abstract/samples:1
+
 #### COINS SUBMODULE XPATH CONFIGURATIONS
 These XPaths are shared within most of the submodules. To see the MODS value after editing an entry, tab to the next field.
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -81,7 +81,7 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
-  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_keyDate_yes_dateIssued_mdt", array(
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt", array(
     '#type' => 'textfield',
     '#title' => t('Google Scholar Publication Date SOLR Field'),
     '#description' => t('The solr date field used to facet by publication date during Google Scholar indexing. <em>Be sure to select a field ending with "_dt" or "_mdt", otherwise solr errors will result during google indexing.</em>'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -81,6 +81,39 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt", array(
+    '#type' => 'textfield',
+    '#title' => t('Google Scholar Publication Date SOLR Field'),
+    '#description' => t('The solr date field used to facet by publication date during Google Scholar indexing. <em>Be sure to select a field ending with "_dt" or "_mdt", otherwise solr errors will result during google indexing.</em>'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_google_scholar_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+  ));
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_abstract_solr_field', "mods_abstract_ms", array(
+    '#type' => 'textfield',
+    '#title' => t('Google Scholar Abstract SOLR Field'),
+    '#description' => t('This is used when displaying object abstracts as required by Google Scholar'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_google_scholar_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+  ));
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel', array(
+    '#type' => 'textfield',
+    '#title' => t('Excluded Content Models'),
+    '#description' => t('Enter a comma-separated list of content model PIDs to exclude from Google Scholar search indexing. <br>For example: <em>islandora:collectionCModel, islandora:newspaperCModel</em>'),
+    '#size' => 120,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_scholar_google_scholar_search_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+  ));
   $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_default_search_xpath', "//mods:mods[1]/mods:titleInfo/mods:title", array(
     '#type' => 'textfield',
     '#title' => t('Google Scholar Default Search XPath'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -81,7 +81,7 @@ function islandora_scholar_admin_form() {
       ),
     ),
   ));
-  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt", array(
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_keyDate_yes_dateIssued_mdt", array(
     '#type' => 'textfield',
     '#title' => t('Google Scholar Publication Date SOLR Field'),
     '#description' => t('The solr date field used to facet by publication date during Google Scholar indexing. <em>Be sure to select a field ending with "_dt" or "_mdt", otherwise solr errors will result during google indexing.</em>'),
@@ -103,10 +103,10 @@ function islandora_scholar_admin_form() {
     ),
     '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
   ));
-  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel', array(
+  $form['google_scholar_search'] += _islandora_scholar_add_variable('islandora_scholar_google_scholar_include_content_types', 'ir:citationCModel, ir:thesisCModel', array(
     '#type' => 'textfield',
-    '#title' => t('Excluded Content Models'),
-    '#description' => t('Enter a comma-separated list of content model PIDs to exclude from Google Scholar search indexing. <br>For example: <em>islandora:collectionCModel, islandora:newspaperCModel</em>'),
+    '#title' => t('Included Content Models'),
+    '#description' => t('Enter a comma-separated list of content model PIDs to include in Google Scholar search indexing. <br>For example: <em>ir:citationCModel, ir:thesisCModel</em>'),
     '#size' => 120,
     '#states' => array(
       'visible' => array(

--- a/includes/google_scholar.inc
+++ b/includes/google_scholar.inc
@@ -194,7 +194,7 @@ function islandora_scholar_create_meta_tags($object) {
     $tags['citation_abstract_html_url'] = url("islandora/object/$object->id/", array('absolute' => TRUE));
   }
 
-  return $tags;
+  return array_filter($tags); // so no tags are created for empty values!
 }
 
 /**

--- a/includes/google_scholar.inc
+++ b/includes/google_scholar.inc
@@ -194,7 +194,8 @@ function islandora_scholar_create_meta_tags($object) {
     $tags['citation_abstract_html_url'] = url("islandora/object/$object->id/", array('absolute' => TRUE));
   }
 
-  return array_filter($tags); // so no tags are created for empty values!
+  // Array filter so no tags are created for empty values!
+  return array_filter($tags);
 }
 
 /**

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -102,7 +102,7 @@ function _islandora_google_scholar_page_years() {
  * @see islandora_google_scholar_menu()
  */
 function _islandora_google_scholar_page_year($year = NULL) {
-  if(empty($year)) {
+  if (empty($year)) {
     $year = (new DateTime)->format("Y");
   }
 
@@ -222,7 +222,7 @@ function _islandora_google_scholar_abstract($pid) {
 function _islandora_google_scholar_get_object_table($search_query, $tag = NULL) {
 
   $query = new IslandoraSolrQueryProcessor();
-  if($tag) {
+  if ($tag) {
     $query->tag = $tag;
   }
 

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -86,22 +86,6 @@ function _islandora_google_scholar_page_years() {
 }
 
 /**
- * Page callback: displays a table of the articles published in a the current year.
- *
- * @see _islandora_google_scholar_page_year().
- *
- * @return string
- * @throws \Exception
- *
- * @see islandora_google_scholar_menu()
- */
-function _islandora_google_scholar_page_current_year() {
-  $year = (new DateTime)->format("Y");
-  return _islandora_google_scholar_page_year($year);
-}
-
-
-/**
  * Page callback: displays a table of the articles published in a given year.
  *
  * Each row in the table provides two links:
@@ -117,7 +101,10 @@ function _islandora_google_scholar_page_current_year() {
  *
  * @see islandora_google_scholar_menu()
  */
-function _islandora_google_scholar_page_year($year) {
+function _islandora_google_scholar_page_year($year = NULL) {
+  if(empty($year)) {
+    $year = (new DateTime)->format("Y");
+  }
 
   if (is_int((int) $year) && abs($year) < 99999) {
     $page_title= 'Google Scholar Year: ' . $year;
@@ -131,42 +118,12 @@ function _islandora_google_scholar_page_year($year) {
     $start = $year . '-01-01T00:00:00Z';
     $end = $year . '-12-31T23:59:59Z';
     $search_query = $solr_field . ':[' . $start . ' TO ' . $end . ']';
-    $query = new IslandoraSolrQueryProcessor();
-    $query->tag = '_islandora_google_scholar_page_year';
 
-    $query->buildQuery($search_query);
-    $query->solrStart = 0;
-    $query->solrLimit = 10000;
-
-    $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-    if ($exclude_types) {
-      $exclude_types = array_map('trim', explode(',', $exclude_types));
-      foreach ($exclude_types as $exclude_type) {
-        $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
-      }
-    }
-    $query->executeQuery();
-    $header = [
-      'View object',
-      'View abstract',
-    ];
-    $rows = [];
-    if (!empty($query->islandoraSolrResult['response']['objects'])) {
-      foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
-        $rows[] = [
-          'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
-          'abstract' => l(t('abstract'), 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
-        ];
-      }
-    }
-    $content = theme('table', [
-      'header' => $header,
-      'rows' => $rows,
-      'empty' => t("No objects found."),
-    ]);
+    $content = _islandora_google_scholar_get_object_table($search_query, '_islandora_google_scholar_page_year');
     $content .= '<div class="weeks">' . l(t('Articles added or updated in the past two weeks'), '/gs_updated') . '</div>';
     return $content;
   }
+  return "No valid year selected";
 }
 
 /**
@@ -190,44 +147,12 @@ function _islandora_google_scholar_updated($weeks = '') {
 
   $breadcrumb = drupal_get_breadcrumb();
   $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
-
-  $search_query = 'fgs_lastModifiedDate_dt:[' . $date_filter . ' TO *]';
-  $query = new IslandoraSolrQueryProcessor();
-  $query->tag = '_islandora_google_scholar_page_weeks';
-
-  $query->buildQuery($search_query);
-  $query->solrStart = 0;
-  $query->solrLimit = 10000;
-
-  $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-  if ($exclude_types) {
-    $exclude_types = array_map('trim', explode(',', $exclude_types));
-    foreach ($exclude_types as $exclude_type) {
-      $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
-    }
-  }
-  $query->executeQuery();
-  $header = [
-    'View object',
-    'View abstract',
-  ];
-  $rows = [];
-  if (!empty($query->islandoraSolrResult['response']['objects'])) {
-    foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
-      $rows[] = [
-        'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
-        'abstract' => l(t('abstract'), 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
-      ];
-    }
-  }
-
   drupal_set_breadcrumb($breadcrumb);
 
-  return theme('table', [
-    'header' => $header,
-    'rows' => $rows,
-    'empty' => t("No objects found."),
-  ]);
+  $search_query = 'fgs_lastModifiedDate_dt:[' . $date_filter . ' TO *]';
+  $content = _islandora_google_scholar_get_object_table($search_query, '_islandora_google_scholar_page_weeks');
+
+  return $content;
 
 }
 
@@ -283,5 +208,54 @@ function _islandora_google_scholar_abstract($pid) {
 
   }
   drupal_not_found();
+
+}
+
+/**
+ * Utility function to show a table of objects found by a solr query
+ *
+ * @param string $search_query
+ * @param null $tag
+ *
+ * @return mixed
+ */
+function _islandora_google_scholar_get_object_table($search_query, $tag = NULL) {
+
+  $query = new IslandoraSolrQueryProcessor();
+  if($tag) {
+    $query->tag = $tag;
+  }
+
+  $query->buildQuery($search_query);
+  $query->solrStart = 0;
+  $query->solrLimit = 10000;
+
+  $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
+  if ($exclude_types) {
+    $exclude_types = array_map('trim', explode(',', $exclude_types));
+    foreach ($exclude_types as $exclude_type) {
+      $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
+    }
+  }
+  $query->executeQuery();
+  $header = [
+    'View object',
+    'View abstract',
+  ];
+  $rows = [];
+  if (!empty($query->islandoraSolrResult['response']['objects'])) {
+    foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
+      $rows[] = [
+        'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
+        'abstract' => l(t('abstract'), 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
+      ];
+    }
+  }
+  return theme('table', [
+    'header' => $header,
+    'rows' => $rows,
+    'empty' => t("No objects found."),
+  ]);
+
 
 }

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -101,8 +101,8 @@ function _islandora_google_scholar_page_years() {
 function _islandora_google_scholar_page_year($year) {
 
   if (is_int((int) $year) && abs($year) < 99999) {
-
-    drupal_set_title(t('Google Scholar Year: ' . $year));
+    $page_title= 'Google Scholar Year: ' . $year;
+    drupal_set_title($page_title);
     $breadcrumb = drupal_get_breadcrumb();
     $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
     drupal_set_breadcrumb($breadcrumb);

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -40,19 +40,23 @@ function _islandora_google_scholar_page_years() {
   $query->solrParams['facet.mincount'] = '1';
   $query->solrParams['facet.limit'] = '2000';
   $query->solrParams['facet.date'] = [$solr_field];
-  $query->solrParams["f.$solr_field.facet.date.start"] = 'NOW/YEAR-20000YEARS';
-  $query->solrParams["f.$solr_field.facet.date.end"] = 'NOW/YEAR+20000YEARS';
+  // To avoid spanning two years, we have to fudge the start and end dates by subtracting 1 millisecond.
+  // See http://lucene.472066.n3.nabble.com/Date-Facet-duplicate-counts-td525335.html
+  $query->solrParams["f.$solr_field.facet.date.start"] = 'NOW/YEAR-20000YEARS-1MILLI';
+  $query->solrParams["f.$solr_field.facet.date.end"] = 'NOW/YEAR+20000YEARS-1MILLI';
   $query->solrParams["f.$solr_field.facet.date.gap"] = '+1YEAR';
   $query->solrParams["f.$solr_field.facet.date.sort"] = 'index';
 
   $query->executeQuery(FALSE);
-  if (!empty($query->islandoraSolrResult['facet_counts']['facet_fields'][$solr_field])) {
+  if (!empty($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field])) {
     $buckets = [];
-    foreach ($query->islandoraSolrResult['facet_counts']['facet_fields'][$solr_field] as $start => $count) {
+    foreach ($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field] as $start => $count) {
       $st = strtotime($start);
       if ($st) {
-        $bucket = idate('Y', $st);
-        if(!empty($buckets[$bucket])) {
+        // The facet start date is 1 millisecond into the prior year. So we add one second to it
+        // before to extracting the year value.
+        $bucket = idate('Y', $st + 1);
+        if (!empty($buckets[$bucket])) {
           $buckets[$bucket]['count'] += $count;
         }
         else {
@@ -78,6 +82,7 @@ function _islandora_google_scholar_page_years() {
     return $content;
 
   }
+  return "No results found.";
 }
 
 /**

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -46,27 +46,25 @@ function _islandora_google_scholar_page_years() {
   $query->solrParams["f.$solr_field.facet.date.sort"] = 'index';
 
   $query->executeQuery(FALSE);
-  if (!empty($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field])) {
-
-    $counts = array_diff_key($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field], array_flip([
-      'gap',
-      'start',
-      'end',
-    ]));
+  if (!empty($query->islandoraSolrResult['facet_counts']['facet_fields'][$solr_field])) {
     $buckets = [];
-    foreach ($counts as $start => $count) {
+    foreach ($query->islandoraSolrResult['facet_counts']['facet_fields'][$solr_field] as $start => $count) {
       $st = strtotime($start);
       if ($st) {
-        $bucket = idate('Y', strtotime($start));
-        $link['link'] = '<a' . drupal_attributes([
-            'rel' => 'nofollow',
-            'href' => url('gs_year/' . $bucket),
-          ]) . '>' . $bucket . '</a>';
-        $link['count'] = $count;
-        $link['link_plus'] = '';
-        $link['link_minus'] = '';
-        $buckets[] = $link;
-
+        $bucket = idate('Y', $st);
+        if(!empty($buckets[$bucket])) {
+          $buckets[$bucket]['count'] += $count;
+        }
+        else {
+          $link['link'] = '<a' . drupal_attributes([
+              'rel' => 'nofollow',
+              'href' => url('gs_year/' . $bucket),
+            ]) . '>' . $bucket . '</a>';
+          $link['count'] = $count;
+          $link['link_plus'] = '';
+          $link['link_minus'] = '';
+          $buckets[$bucket] = $link;
+        }
       }
     }
 
@@ -81,6 +79,22 @@ function _islandora_google_scholar_page_years() {
 
   }
 }
+
+/**
+ * Page callback: displays a table of the articles published in a the current year.
+ *
+ * @see _islandora_google_scholar_page_year().
+ *
+ * @return string
+ * @throws \Exception
+ *
+ * @see islandora_google_scholar_menu()
+ */
+function _islandora_google_scholar_page_current_year() {
+  $year = (new DateTime)->format("Y");
+  return _islandora_google_scholar_page_year($year);
+}
+
 
 /**
  * Page callback: displays a table of the articles published in a given year.
@@ -110,7 +124,7 @@ function _islandora_google_scholar_page_year($year) {
     $solr_field = variable_get('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt");
 
     $start = $year . '-01-01T00:00:00Z';
-    $end = gmdate('Y-m-d\TH:i:s\Z', strtotime('+1 year', strtotime($start)));
+    $end = $year . '-12-31T23:59:59Z';
     $search_query = $solr_field . ':[' . $start . ' TO ' . $end . ']';
     $query = new IslandoraSolrQueryProcessor();
     $query->tag = '_islandora_google_scholar_page_year';

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * Module used provide Google Scholar with required aggregation pages.
+ */
+
+/**
  * Page callback: displays a list of years that have articles.
  *
  * Each year is a link to another page that displays a table of articles
@@ -10,6 +15,7 @@
  * from earliest to latest.
  *
  * @return string
+ *   HTML containing a list of years that have articles.
  * @throws \Exception
  *
  * @see islandora_google_scholar_menu()
@@ -24,9 +30,9 @@ function _islandora_google_scholar_page_years() {
   $query->solrStart = 0;
   $query->solrLimit = 0;
   $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-  if($exclude_types) {
+  if ($exclude_types) {
     $exclude_types = array_map('trim', explode(',', $exclude_types));
-    foreach($exclude_types as $exclude_type) {
+    foreach ($exclude_types as $exclude_type) {
       $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
     }
   }
@@ -41,7 +47,6 @@ function _islandora_google_scholar_page_years() {
 
   $query->executeQuery(FALSE);
   if (!empty($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field])) {
-
 
     $counts = array_diff_key($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field], array_flip([
       'gap',
@@ -71,7 +76,7 @@ function _islandora_google_scholar_page_years() {
       'pid' => '',
     ]);
 
-    $content .= '<div class="weeks">' . l('Articles added or updated in the past two weeks', '/gs_updated') . '</div>';
+    $content .= '<div class="weeks">' . l(t('Articles added or updated in the past two weeks'), '/gs_updated') . '</div>';
     return $content;
 
   }
@@ -84,9 +89,11 @@ function _islandora_google_scholar_page_years() {
  *   - To the standard islandora object page
  *   - To a page that displays just the title and the contents of the abstract.
  *
- * @param $year
+ * @param int $year
+ *   The year for which you want a full list of related articles.
  *
  * @return string
+ *   HTML containing a table of the articles published in a given year.
  * @throws \Exception
  *
  * @see islandora_google_scholar_menu()
@@ -95,9 +102,9 @@ function _islandora_google_scholar_page_year($year) {
 
   if (is_int((int) $year) && abs($year) < 99999) {
 
-    drupal_set_title(t('Google Scholar Year: ' . $year));
+    drupal_set_title('Google Scholar Year: ' . $year);
     $breadcrumb = drupal_get_breadcrumb();
-    $breadcrumb[] = l('Google Scholar Years', 'gs_years');
+    $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
     drupal_set_breadcrumb($breadcrumb);
 
     $solr_field = variable_get('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt");
@@ -113,9 +120,9 @@ function _islandora_google_scholar_page_year($year) {
     $query->solrLimit = 10000;
 
     $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-    if($exclude_types) {
+    if ($exclude_types) {
       $exclude_types = array_map('trim', explode(',', $exclude_types));
-      foreach($exclude_types as $exclude_type) {
+      foreach ($exclude_types as $exclude_type) {
         $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
       }
     }
@@ -129,7 +136,7 @@ function _islandora_google_scholar_page_year($year) {
       foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
         $rows[] = [
           'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
-          'abstract' => l('abstract', 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
+          'abstract' => l(t('abstract'), 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
         ];
       }
     }
@@ -138,18 +145,20 @@ function _islandora_google_scholar_page_year($year) {
       'rows' => $rows,
       'empty' => t("No objects found."),
     ]);
-    $content .= '<div class="weeks">' . l('Articles added or updated in the past two weeks', '/gs_updated') . '</div>';
+    $content .= '<div class="weeks">' . l(t('Articles added or updated in the past two weeks'), '/gs_updated') . '</div>';
     return $content;
   }
 }
 
 /**
- * Page callback: displays a list of articles created or modified in the past N weeks.
+ * Page callback: displays list of articles created or modified in past N weeks.
  *
  * @param string $weeks
  *   defaults to 2 weeks.
  *
  * @return string
+ *   HTML page content.
+ *
  * @throws \Exception
  *
  * @see islandora_google_scholar_menu()
@@ -157,11 +166,11 @@ function _islandora_google_scholar_page_year($year) {
 function _islandora_google_scholar_updated($weeks = '') {
   $weeks = !empty($weeks) && is_int((int) $weeks) ? (int) $weeks : 2;
 
-  drupal_set_title(format_plural($weeks, 'Added/updated objects in the past week' ,'Added/updated objects in the past @count weeks'));
+  drupal_set_title(format_plural($weeks, 'Added/updated objects in the past week', 'Added/updated objects in the past @count weeks'));
   $date_filter = gmdate('Y-m-d\TH:i:s\Z', strtotime('-' . $weeks . ' weeks'));
 
   $breadcrumb = drupal_get_breadcrumb();
-  $breadcrumb[] = l('Google Scholar Years', 'gs_years');
+  $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
 
   $search_query = 'fgs_lastModifiedDate_dt:[' . $date_filter . ' TO *]';
   $query = new IslandoraSolrQueryProcessor();
@@ -172,9 +181,9 @@ function _islandora_google_scholar_updated($weeks = '') {
   $query->solrLimit = 10000;
 
   $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-  if($exclude_types) {
+  if ($exclude_types) {
     $exclude_types = array_map('trim', explode(',', $exclude_types));
-    foreach($exclude_types as $exclude_type) {
+    foreach ($exclude_types as $exclude_type) {
       $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
     }
   }
@@ -188,7 +197,7 @@ function _islandora_google_scholar_updated($weeks = '') {
     foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
       $rows[] = [
         'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
-        'abstract' => l('abstract', 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
+        'abstract' => l(t('abstract'), 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
       ];
     }
   }
@@ -204,12 +213,13 @@ function _islandora_google_scholar_updated($weeks = '') {
 }
 
 /**
- * Page callback: provides an extremely basic view of a given object, showing
- * just the title and the abstract.
+ * Page callback: provides just the title and the abstract for given object.
  *
- * @param $pid
+ * @param string $pid
+ *   The PID of the object you which to display the abstract for.
  *
  * @return string
+ *   HTML page content.
  *
  * @see islandora_google_scholar_menu()
  */
@@ -219,7 +229,7 @@ function _islandora_google_scholar_abstract($pid) {
   }
 
   $breadcrumb = drupal_get_breadcrumb();
-  $breadcrumb[] = l('Google Scholar Years', 'gs_years');
+  $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
 
   $solr_abstract_field = variable_get('islandora_scholar_google_scholar_abstract_solr_field', "mods_abstract_ms");
   $pid = preg_replace('#:#', '\\:', $pid);
@@ -244,12 +254,12 @@ function _islandora_google_scholar_abstract($pid) {
     }
     $params = drupal_get_query_parameters();
     if (!empty($params['destination'])) {
-      $breadcrumb[] = l('Search', $params['destination']);
+      $breadcrumb[] = l(t('Search'), $params['destination']);
     }
     $breadcrumb[] = l($label, $result['object_url']);
     drupal_set_breadcrumb($breadcrumb);
 
-    $content .= '<div class="weeks">' . l('Articles added or updated in the past two weeks', '/gs_updated') . '</div>';
+    $content .= '<div class="weeks">' . l(t('Articles added or updated in the past two weeks'), '/gs_updated') . '</div>';
     return $content;
 
   }

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -102,7 +102,7 @@ function _islandora_google_scholar_page_year($year) {
 
   if (is_int((int) $year) && abs($year) < 99999) {
 
-    drupal_set_title('Google Scholar Year: ' . $year);
+    drupal_set_title(t('Google Scholar Year: ' . $year));
     $breadcrumb = drupal_get_breadcrumb();
     $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
     drupal_set_breadcrumb($breadcrumb);

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Page callback: displays a list of years that have articles.
+ *
+ * Each year is a link to another page that displays a table of articles
+ * published in that year.
+ *
+ * Solr range faceting is used to generate the list of years. They are sorted
+ * from earliest to latest.
+ *
+ * @return string
+ * @throws \Exception
+ *
+ * @see islandora_google_scholar_menu()
+ */
+function _islandora_google_scholar_page_years() {
+  $solr_field = variable_get('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt");
+  $query = new IslandoraSolrQueryProcessor();
+  $query->tag = '_islandora_google_scholar_page_years';
+  $query->buildQuery('');
+  $query->solrQuery = '';
+  $query->internalSolrQuery = variable_get('islandora_solr_base_query', '*:*');
+  $query->solrStart = 0;
+  $query->solrLimit = 0;
+  $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
+  if($exclude_types) {
+    $exclude_types = array_map('trim', explode(',', $exclude_types));
+    foreach($exclude_types as $exclude_type) {
+      $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
+    }
+  }
+  $query->solrParams['facet'] = 'true';
+  $query->solrParams['facet.mincount'] = '1';
+  $query->solrParams['facet.limit'] = '2000';
+  $query->solrParams['facet.date'] = [$solr_field];
+  $query->solrParams["f.$solr_field.facet.date.start"] = 'NOW/YEAR-20000YEARS';
+  $query->solrParams["f.$solr_field.facet.date.end"] = 'NOW/YEAR+20000YEARS';
+  $query->solrParams["f.$solr_field.facet.date.gap"] = '+1YEAR';
+  $query->solrParams["f.$solr_field.facet.date.sort"] = 'index';
+
+  $query->executeQuery(FALSE);
+  if (!empty($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field])) {
+
+
+    $counts = array_diff_key($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field], array_flip([
+      'gap',
+      'start',
+      'end',
+    ]));
+    $buckets = [];
+    foreach ($counts as $start => $count) {
+      $st = strtotime($start);
+      if ($st) {
+        $bucket = idate('Y', strtotime($start));
+        $link['link'] = '<a' . drupal_attributes([
+            'rel' => 'nofollow',
+            'href' => url('gs_year/' . $bucket),
+          ]) . '>' . $bucket . '</a>';
+        $link['count'] = $count;
+        $link['link_plus'] = '';
+        $link['link_minus'] = '';
+        $buckets[] = $link;
+
+      }
+    }
+
+    $content = theme('islandora_solr_facet', [
+      'buckets' => $buckets,
+      'hidden' => FALSE,
+      'pid' => '',
+    ]);
+
+    $content .= '<div class="weeks">' . l('Articles added or updated in the past two weeks', '/gs_updated') . '</div>';
+    return $content;
+
+  }
+}
+
+/**
+ * Page callback: displays a table of the articles published in a given year.
+ *
+ * Each row in the table provides two links:
+ *   - To the standard islandora object page
+ *   - To a page that displays just the title and the contents of the abstract.
+ *
+ * @param $year
+ *
+ * @return string
+ * @throws \Exception
+ *
+ * @see islandora_google_scholar_menu()
+ */
+function _islandora_google_scholar_page_year($year) {
+
+  if (is_int((int) $year) && abs($year) < 99999) {
+
+    drupal_set_title(t('Google Scholar Year: ' . $year));
+    $breadcrumb = drupal_get_breadcrumb();
+    $breadcrumb[] = l('Google Scholar Years', 'gs_years');
+    drupal_set_breadcrumb($breadcrumb);
+
+    $solr_field = variable_get('islandora_scholar_google_scholar_publication_date_solr_field', "mods_originInfo_dateIssued_mdt");
+
+    $start = $year . '-01-01T00:00:00Z';
+    $end = gmdate('Y-m-d\TH:i:s\Z', strtotime('+1 year', strtotime($start)));
+    $search_query = $solr_field . ':[' . $start . ' TO ' . $end . ']';
+    $query = new IslandoraSolrQueryProcessor();
+    $query->tag = '_islandora_google_scholar_page_year';
+
+    $query->buildQuery($search_query);
+    $query->solrStart = 0;
+    $query->solrLimit = 10000;
+
+    $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
+    if($exclude_types) {
+      $exclude_types = array_map('trim', explode(',', $exclude_types));
+      foreach($exclude_types as $exclude_type) {
+        $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
+      }
+    }
+    $query->executeQuery();
+    $header = [
+      'View object',
+      'View abstract',
+    ];
+    $rows = [];
+    if (!empty($query->islandoraSolrResult['response']['objects'])) {
+      foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
+        $rows[] = [
+          'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
+          'abstract' => l('abstract', 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
+        ];
+      }
+    }
+    $content = theme('table', [
+      'header' => $header,
+      'rows' => $rows,
+      'empty' => t("No objects found."),
+    ]);
+    $content .= '<div class="weeks">' . l('Articles added or updated in the past two weeks', '/gs_updated') . '</div>';
+    return $content;
+  }
+}
+
+/**
+ * Page callback: displays a list of articles created or modified in the past N weeks.
+ *
+ * @param string $weeks
+ *   defaults to 2 weeks.
+ *
+ * @return string
+ * @throws \Exception
+ *
+ * @see islandora_google_scholar_menu()
+ */
+function _islandora_google_scholar_updated($weeks = '') {
+  $weeks = !empty($weeks) && is_int((int) $weeks) ? (int) $weeks : 2;
+
+  drupal_set_title(format_plural($weeks, 'Added/updated objects in the past week' ,'Added/updated objects in the past @count weeks'));
+  $date_filter = gmdate('Y-m-d\TH:i:s\Z', strtotime('-' . $weeks . ' weeks'));
+
+  $breadcrumb = drupal_get_breadcrumb();
+  $breadcrumb[] = l('Google Scholar Years', 'gs_years');
+
+  $search_query = 'fgs_lastModifiedDate_dt:[' . $date_filter . ' TO *]';
+  $query = new IslandoraSolrQueryProcessor();
+  $query->tag = '_islandora_google_scholar_page_weeks';
+
+  $query->buildQuery($search_query);
+  $query->solrStart = 0;
+  $query->solrLimit = 10000;
+
+  $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
+  if($exclude_types) {
+    $exclude_types = array_map('trim', explode(',', $exclude_types));
+    foreach($exclude_types as $exclude_type) {
+      $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
+    }
+  }
+  $query->executeQuery();
+  $header = [
+    'View object',
+    'View abstract',
+  ];
+  $rows = [];
+  if (!empty($query->islandoraSolrResult['response']['objects'])) {
+    foreach ($query->islandoraSolrResult['response']['objects'] as $result) {
+      $rows[] = [
+        'link' => l($result['object_label'], $result['object_url'], ['query' => drupal_get_destination()]),
+        'abstract' => l('abstract', 'gs_abstract/' . $result['PID'], ['query' => drupal_get_destination()]),
+      ];
+    }
+  }
+
+  drupal_set_breadcrumb($breadcrumb);
+
+  return theme('table', [
+    'header' => $header,
+    'rows' => $rows,
+    'empty' => t("No objects found."),
+  ]);
+
+}
+
+/**
+ * Page callback: provides an extremely basic view of a given object, showing
+ * just the title and the abstract.
+ *
+ * @param $pid
+ *
+ * @return string
+ *
+ * @see islandora_google_scholar_menu()
+ */
+function _islandora_google_scholar_abstract($pid) {
+  if (is_null($pid)) {
+    drupal_not_found();
+  }
+
+  $breadcrumb = drupal_get_breadcrumb();
+  $breadcrumb[] = l('Google Scholar Years', 'gs_years');
+
+  $solr_abstract_field = variable_get('islandora_scholar_google_scholar_abstract_solr_field', "mods_abstract_ms");
+  $pid = preg_replace('#:#', '\\:', $pid);
+
+  $qp = new IslandoraSolrQueryProcessor();
+  $query = 'PID:"' . $pid . '"';
+  $qp->buildQuery($query);
+  $qp->solrParams['fl'] = 'PID, fgs_label_s, ' . $solr_abstract_field;
+  $qp->solrStart = 0;
+  $qp->solrLimit = 1;
+  $qp->executeQuery(FALSE);
+  if (!empty($qp->islandoraSolrResult['response']['objects'])) {
+    $result = reset($qp->islandoraSolrResult['response']['objects']);
+    $label = !empty($result['object_label']) ? $result['object_label'] : $pid;
+    drupal_set_title(t('Abstract: @label', ['@label' => $label]));
+    $content = !empty($result['solr_doc'][$solr_abstract_field]) ? $result['solr_doc'][$solr_abstract_field] : '';
+    if (is_array($content)) {
+      $content = '<div class="abstract">' . implode('</div><div class="abstract">', $content) . '</div>';
+    }
+    else {
+      $content = '<div class="no-abstract">' . t('No abstract available for this item.') . '</div>';
+    }
+    $params = drupal_get_query_parameters();
+    if (!empty($params['destination'])) {
+      $breadcrumb[] = l('Search', $params['destination']);
+    }
+    $breadcrumb[] = l($label, $result['object_url']);
+    drupal_set_breadcrumb($breadcrumb);
+
+    $content .= '<div class="weeks">' . l('Articles added or updated in the past two weeks', '/gs_updated') . '</div>';
+    return $content;
+
+  }
+  drupal_not_found();
+
+}

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -29,13 +29,17 @@ function _islandora_google_scholar_page_years() {
   $query->internalSolrQuery = variable_get('islandora_solr_base_query', '*:*');
   $query->solrStart = 0;
   $query->solrLimit = 0;
-  $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-  if ($exclude_types) {
-    $exclude_types = array_map('trim', explode(',', $exclude_types));
-    foreach ($exclude_types as $exclude_type) {
-      $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
+
+  $include_types = variable_get('islandora_scholar_google_scholar_include_content_types', 'ir:citationCModel,ir:thesisCModel');
+  if ($include_types) {
+    $content_model_solr_field = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
+    $include_types = array_map('trim', explode(',', $include_types));
+    foreach($include_types as $key => $include_type) {
+      $include_types[$key] = $content_model_solr_field . ':"info:fedora/' . $include_type . '"';
     }
+    $query->solrParams['fq'][] = implode(' OR ', $include_types);
   }
+
   $query->solrParams['facet'] = 'true';
   $query->solrParams['facet.mincount'] = '1';
   $query->solrParams['facet.limit'] = '2000';
@@ -49,37 +53,45 @@ function _islandora_google_scholar_page_years() {
 
   $query->executeQuery(FALSE);
   if (!empty($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field])) {
-    $buckets = [];
-    foreach ($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field] as $start => $count) {
-      $st = strtotime($start);
-      if ($st) {
-        // The facet start date is 1 millisecond into the prior year. So we add one second to it
-        // before to extracting the year value.
-        $bucket = idate('Y', $st + 1);
-        if (!empty($buckets[$bucket])) {
-          $buckets[$bucket]['count'] += $count;
-        }
-        else {
-          $link['link'] = '<a' . drupal_attributes([
-              'rel' => 'nofollow',
-              'href' => url('gs_year/' . $bucket),
-            ]) . '>' . $bucket . '</a>';
-          $link['count'] = $count;
-          $link['link_plus'] = '';
-          $link['link_minus'] = '';
-          $buckets[$bucket] = $link;
+    $query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field] = array_diff_key($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field], array_flip([
+      'gap',
+      'start',
+      'end'
+    ]));
+    if (!empty($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field])) {
+
+      $buckets = [];
+      foreach ($query->islandoraSolrResult['facet_counts']['facet_dates'][$solr_field] as $start => $count) {
+        $st = strtotime($start);
+        if ($st) {
+          // The facet start date is 1 millisecond into the prior year. So we add one second to it
+          // before to extracting the year value.
+          $bucket = idate('Y', $st + 1);
+          if (!empty($buckets[$bucket])) {
+            $buckets[$bucket]['count'] += $count;
+          }
+          else {
+            $link['link'] = '<a' . drupal_attributes([
+                'rel' => 'nofollow',
+                'href' => url('gs_year/' . $bucket),
+              ]) . '>' . $bucket . '</a>';
+            $link['count'] = $count;
+            $link['link_plus'] = '';
+            $link['link_minus'] = '';
+            $buckets[$bucket] = $link;
+          }
         }
       }
+
+      $content = theme('islandora_solr_facet', [
+        'buckets' => $buckets,
+        'hidden' => FALSE,
+        'pid' => '',
+      ]);
+
+      $content .= '<div class="weeks">' . l(t('Articles added or updated in the past two weeks'), '/gs_updated') . '</div>';
+      return $content;
     }
-
-    $content = theme('islandora_solr_facet', [
-      'buckets' => $buckets,
-      'hidden' => FALSE,
-      'pid' => '',
-    ]);
-
-    $content .= '<div class="weeks">' . l(t('Articles added or updated in the past two weeks'), '/gs_updated') . '</div>';
-    return $content;
 
   }
   return "No results found.";
@@ -107,7 +119,7 @@ function _islandora_google_scholar_page_year($year = NULL) {
   }
 
   if (is_int((int) $year) && abs($year) < 99999) {
-    $page_title= 'Google Scholar Year: ' . $year;
+    $page_title= 'Scholarly articles published in ' . $year;
     drupal_set_title($page_title);
     $breadcrumb = drupal_get_breadcrumb();
     $breadcrumb[] = l(t('Google Scholar Years'), 'gs_years');
@@ -142,7 +154,7 @@ function _islandora_google_scholar_page_year($year = NULL) {
 function _islandora_google_scholar_updated($weeks = '') {
   $weeks = !empty($weeks) && is_int((int) $weeks) ? (int) $weeks : 2;
 
-  drupal_set_title(format_plural($weeks, 'Added/updated objects in the past week', 'Added/updated objects in the past @count weeks'));
+  drupal_set_title(format_plural($weeks, 'Added/updated scholarly articles in the past week', 'Added/updated scholarly articles in the past @count weeks'));
   $date_filter = gmdate('Y-m-d\TH:i:s\Z', strtotime('-' . $weeks . ' weeks'));
 
   $breadcrumb = drupal_get_breadcrumb();
@@ -230,13 +242,16 @@ function _islandora_google_scholar_get_object_table($search_query, $tag = NULL) 
   $query->solrStart = 0;
   $query->solrLimit = 10000;
 
-  $exclude_types = variable_get('islandora_scholar_google_scholar_exclude_content_types', 'islandora:collectionCModel');
-  if ($exclude_types) {
-    $exclude_types = array_map('trim', explode(',', $exclude_types));
-    foreach ($exclude_types as $exclude_type) {
-      $query->solrParams['fq'][] = '-RELS_EXT_hasModel_uri_s: "info:fedora/' . $exclude_type . '"';
+  $include_types = variable_get('islandora_scholar_google_scholar_include_content_types', 'ir:citationCModel,ir:thesisCModel');
+  if ($include_types) {
+    $content_model_solr_field = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
+    $include_types = array_map('trim', explode(',', $include_types));
+    foreach($include_types as $key => $include_type) {
+      $include_types[$key] = $content_model_solr_field . ':"info:fedora/' . $include_type . '"';
     }
+    $query->solrParams['fq'][] = implode(' OR ', $include_types);
   }
+
   $query->executeQuery();
   $header = [
     'View object',

--- a/includes/page_callbacks.inc
+++ b/includes/page_callbacks.inc
@@ -34,7 +34,7 @@ function _islandora_google_scholar_page_years() {
   if ($include_types) {
     $content_model_solr_field = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
     $include_types = array_map('trim', explode(',', $include_types));
-    foreach($include_types as $key => $include_type) {
+    foreach ($include_types as $key => $include_type) {
       $include_types[$key] = $content_model_solr_field . ':"info:fedora/' . $include_type . '"';
     }
     $query->solrParams['fq'][] = implode(' OR ', $include_types);
@@ -246,7 +246,7 @@ function _islandora_google_scholar_get_object_table($search_query, $tag = NULL) 
   if ($include_types) {
     $content_model_solr_field = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
     $include_types = array_map('trim', explode(',', $include_types));
-    foreach($include_types as $key => $include_type) {
+    foreach ($include_types as $key => $include_type) {
       $include_types[$key] = $content_model_solr_field . ':"info:fedora/' . $include_type . '"';
     }
     $query->solrParams['fq'][] = implode(' OR ', $include_types);

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -85,6 +85,15 @@ function islandora_scholar_menu() {
       ),
       'type' => MENU_CALLBACK,
     ),
+    'gs_year' => array(
+      'title' => 'Google Scholar Current Year',
+      'page callback' => '_islandora_google_scholar_page_current_year',
+      'file' => 'includes/page_callbacks.inc',
+      'access arguments' => array(
+        'access content',
+      ),
+      'type' => MENU_CALLBACK,
+    ),
     'gs_year/%' => array(
       'title' => 'Google Scholar Year',
       'page callback' => '_islandora_google_scholar_page_year',

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -68,7 +68,7 @@ function islandora_scholar_menu() {
       'file' => 'includes/callbacks.inc',
     ),
     'gs_years' => array(
-      'title' => 'Google Scholar Years',
+      'title' => 'Scholarly article publications by year',
       'page callback' => '_islandora_google_scholar_page_years',
       'file' => 'includes/page_callbacks.inc',
       'access arguments' => array(

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -67,6 +67,44 @@ function islandora_scholar_menu() {
       'access arguments' => array(2),
       'file' => 'includes/callbacks.inc',
     ),
+    'gs_years' => array(
+      'title' => 'Google Scholar Years',
+      'page callback' => '_islandora_google_scholar_page_years',
+      'file' => 'includes/page_callbacks.inc',
+      'access arguments' => array(
+        'access content',
+      ),
+      'type' => MENU_CALLBACK,
+    ),
+    'gs_updated' => array(
+      'title' => 'Google Scholar Articles Added/Updated',
+      'page callback' => '_islandora_google_scholar_updated',
+      'file' => 'includes/page_callbacks.inc',
+      'access arguments' => array(
+        'access content',
+      ),
+      'type' => MENU_CALLBACK,
+    ),
+    'gs_year/%' => array(
+      'title' => 'Google Scholar Year',
+      'page callback' => '_islandora_google_scholar_page_year',
+      'page arguments' => array(1),
+      'file' => 'includes/page_callbacks.inc',
+      'access arguments' => array(
+        'access content',
+      ),
+      'type' => MENU_CALLBACK,
+    ),
+    'gs_abstract/%' => array(
+      'title' => 'Abstract',
+      'page callback' => '_islandora_google_scholar_abstract',
+      'page arguments' => array(1),
+      'file' => 'includes/page_callbacks.inc',
+      'access arguments' => array(
+        'access content',
+      ),
+      'type' => MENU_CALLBACK,
+    ),
   );
 }
 

--- a/islandora_scholar.module
+++ b/islandora_scholar.module
@@ -86,18 +86,8 @@ function islandora_scholar_menu() {
       'type' => MENU_CALLBACK,
     ),
     'gs_year' => array(
-      'title' => 'Google Scholar Current Year',
-      'page callback' => '_islandora_google_scholar_page_current_year',
-      'file' => 'includes/page_callbacks.inc',
-      'access arguments' => array(
-        'access content',
-      ),
-      'type' => MENU_CALLBACK,
-    ),
-    'gs_year/%' => array(
       'title' => 'Google Scholar Year',
       'page callback' => '_islandora_google_scholar_page_year',
-      'page arguments' => array(1),
       'file' => 'includes/page_callbacks.inc',
       'access arguments' => array(
         'access content',


### PR DESCRIPTION
(my first Islandora PR, so please let me know if this needs improvement/cleanup in any way...)


**JIRA Ticket**: 1816 - this delivers functionality expected from recent conversations with the Google Scholar team (see below).

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

The purpose of this is to ensure that automatic crawlers are able to discover and fetch the URLs of all articles, as well as to periodically refresh their content. In Google Scholar setup (https://partnerdash.google.com/partnerdash/d/scholarinclusions#p:id=new), you are asked to provide the following:

Please provide the URL of a page listing all years available.
Please provide examples of URLs to pages that provide a list of articles for a given year.
Please provide examples of individual abstract pages.
Please provide examples of full-text article URLs. Please pick some recently added articles as well as some articles that were added a while ago.
The first two will require creating custom displays, while the third and fourth require no additional functionality. In addition, for larger repositories, GS recommends providing a page that lists items added in the last two weeks. So this part of the task requires building three pages:

A page that lists years. I think the way to do this is to have a custom page which runs a solr query returning zero rows, and faceted with a facet.date.gap of a year.
A page listing articles, filtered by a year parameter in the url.
A page showing articles added/updated in the past two weeks.


# What's new?

These requirements are intended to be met in this commit as follows:

- New pages added:
  - /gs_years: Lists all years when articles were published.
  - /gs_year/%: Lists all articles published in a given year
  - /gs_updated: Lists all articles added or updated in the repository in the past two weeks
  - /gs_abstract/%: Displays a very basic page showing the title and abstract for a given object
- Expanded islandora_scholar configuration form:
  - Added fields to the Google Scholar section for which solr fields to use for publication date and abstract, and which content models to exclude from these pages.
- Documented these enhancements in the islandora_google_scholar README file.

# How should this be tested?

Review new admin settings on `/admin/islandora/solution_pack_config/scholar`, activated by enabling "Render Google Scholar Search Link". Review new Google Scholar submission requirement pages at `gs_years`, `gs_year/:year:`, `gs_abstract/:pid:`. 


# Additional Notes:
This was part of the LASIR project, developed by Born-Digital (Noah Smith and Pat Dunlavey) in consultation with Bryan Brown and Donald Moses. 

# Interested parties
@bryjbrown @dmoses @patdunlavey 
