### PR TITLE
Let's use the first value in the array

### DIFF
--- a/islandora_scholar.install
+++ b/islandora_scholar.install
@@ -156,7 +156,7 @@ function islandora_scholar_update_7103(&$sandbox) {
  */
 function islandora_scholar_update_7104(&$sandbox) {
   $module = array('islandora_google_scholar');
-  if (module_exists($module)) {
+  if (module_exists($module[0])) {
     module_disable($module, FALSE);
   }
   db_delete('system')


### PR DESCRIPTION
**ISLANDORA-2491**: (https://jira.duraspace.org/browse/ISLANDORA-2491)

# What does this Pull Request do?
Corrects the usage of module_exists in the 7104 update hook.

# How should this be tested?
Considering a server that has a version of the module older than a52d14721a81b7a549eb32b26e62520c13b30853 installed and enabled:
- Update the module and clear caches
- The following error is encountered:

> The following module is missing from the file system: islandora_google_scholar. For information about how to fix this, see the documentation page. in _drupal_trigger_error_with_delayed_logging() (line 1156 of /var/www/drupal7/includes/bootstrap.inc).

- Running the update hook again on the command line will yield:
> Warning: Illegal offset type in isset or empty in module_exists() (line 280 of /var/www/drupal7/includes/module.inc)
- After merging the code, re-running the 7104 update hook for this module rectifies the issue.

# Interested parties
@DonRichards 
@willtp87 
