### PR TITLE
2503: Encode Google Scholar search terms

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -66,7 +66,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       if (!$search_term) {
         $search_term = $object->label;
       }
-
+      $search_term = urlencode($search_term);
       $display['google_scholar_search'] = array(
         '#type' => 'item',
         '#markup' => l(t('Search for this publication on Google Scholar'), "http://scholar.google.ca/scholar?q=\"$search_term\"", array('attributes' => array('class' => 'scholar-google-scholar-search-link'))),
@@ -98,7 +98,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
       if (!$search_term) {
         $search_term = $object->label;
       }
-
+      $search_term = urlencode($search_term);
       $display['library_catalog_search'] = array(
         '#type' => 'item',
         '#markup' => l(t('Search for this publication in your library discovery service'), "$search_url$search_params\"$search_term\""),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2503

# What does this Pull Request do?

Encodes the Search Terms going into the Google Scholar and Catalogue Search links.

# What's new?

Search terms (especially article title) passed to Google Scholar and the library catalogue are now encoded, where before any special characters were passed along directly and caused the search to fail.

# How should this be tested?

* In Islandora Scholar, enable Google Scholar Search Link
* Ingest an object with special characters in the title, i.e. `#NoHomo: men's friendships, or 'something else'` (and do not add a DOI)
* Click the GS search link that is generated; you get special characters in the URL and the search fails.
* Check out this branch and refresh
* Click the new GS link; good results!
* Edit the object to add a valid DOI, click the search link again; results should still be good

# Interested parties
@Islandora/7-x-1-x-committers
