### PR TITLE
This is a replacement pull request for #323

### DIFF
--- a/includes/google_scholar.inc
+++ b/includes/google_scholar.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Module used to embed meta tags in the HEAD for use in indexing in Google
@@ -16,7 +15,7 @@
  *   Associative array where the key is the name of the tag and the value is
  *   the content.
  */
-function islandora_scholar_create_meta_tags($object) {
+function islandora_google_scholar_create_meta_tags($object) {
   // Need at least title, full name of at least one author, publication year.
   if (!isset($object['MODS']) || !islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS'])) {
     return FALSE;
@@ -44,35 +43,45 @@ function islandora_scholar_create_meta_tags($object) {
     else {
       return FALSE;
     }
-    foreach ($mods_xml->xpath('mods:name') as $name_xml) {
+    foreach ($mods_xml->xpath(variable_get('islandora_scholar_xpaths_authors_xpath', 'mods:name')) as $name_xml) {
       $name_parts = array();
       $name_xml->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
-      $roles = $name_xml->xpath('mods:role/mods:roleTerm');
-      $role = strtolower((string) reset($roles));
-      if ($role) {
-        if ($role == 'author') {
-          foreach ($name_xml->xpath('mods:namePart') as $name_part) {
-            if ((string) $name_part != '') {
-              // Strip periods off the end.
-              $np = (string) rtrim($name_part, '.');
-              if ($name_part['type'] == 'given') {
-                $name_parts['first_name'] = (string) $name_part;
-              }
-              if ($name_part['type'] == 'family') {
-                $name_parts['last_name'] = $np;
-              }
-              if (!isset($name_part['type'])) {
-                $name_parts['no_type'] = $np;
-              }
+      // Use Mods DisplayForm as a backup source for name.
+      // Only taking the first result for displayForm.
+      $name_displayForm = '';
+      $mods_displayform = $name_xml->xpath('mods:displayForm');
+      if (is_array($mods_displayform)) {
+        $name_displayForm = array_shift($mods_displayform);
+      }
+      foreach ($name_xml->xpath('mods:namePart') as $name_part) {
+        if ((string) $name_part != '') {
+          // Strip periods off the end.
+          $np = (string) rtrim($name_part, '.');
+          if ($name_part['type'] == 'given') {
+            // Middle name is also marked as given name in MODS.
+            if (isset($name_parts['first_name'])) {
+              $name_parts['first_name'] = $name_parts['first_name'] . ' ' . (string) $name_part;
+            }
+            else {
+              $name_parts['first_name'] = (string) $name_part;
             }
           }
+          if ($name_part['type'] == 'family') {
+            $name_parts['last_name'] = $np;
+          }
+          if (!isset($name_part['type'])) {
+            $name_parts['no_type'] = $np;
+          }
         }
-        if (isset($name_parts['last_name']) && isset($name_parts['first_name'])) {
-          $tags['citation_author'][] = $name_parts['last_name'] . ', ' . $name_parts['first_name'];
-        }
-        elseif (isset($name_parts['no_type'])) {
-          $tags['citation_author'][] = $name_parts['no_type'];
-        }
+      }
+      if (isset($name_parts['last_name']) && isset($name_parts['first_name'])) {
+        $tags['citation_author'][] = $name_parts['last_name'] . ', ' . $name_parts['first_name'];
+      }
+      elseif ($name_displayForm != '') {
+        $tags['citation_author'][] = $name_displayForm;
+      }
+      elseif (isset($name_parts['no_type'])) {
+        $tags['citation_author'][] = $name_parts['no_type'];
       }
     }
     if (count($tags['citation_author']) == 0) {
@@ -103,9 +112,8 @@ function islandora_scholar_create_meta_tags($object) {
     // Google requires dates in yy/mm/dd format or just the year. As dates suck
     // and we don't have a consistent structure of input we will just return the
     // year for now.
-
     if ($date) {
-      $date_string = islandora_scholar_parse_date_foryear($date);
+      $date_string = islandora_google_scholar_parse_date_foryear($date);
       if ($date_string) {
         $tags['citation_publication_date'] = $date_string;
       }
@@ -116,7 +124,6 @@ function islandora_scholar_create_meta_tags($object) {
 
     $host_title = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_host_title', '//mods:relatedItem[@type="host"]//mods:title'));
     $genre = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_genre', '//mods:mods[1]/mods:genre'));
-
     $genre = strtolower((string) reset($genre));
     switch ($genre) {
       case 'book section':
@@ -171,7 +178,7 @@ function islandora_scholar_create_meta_tags($object) {
 
     $online_date = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_online_date', '//mods:recordInfo/mods:recordCreationDate'));
     if ($online_date) {
-      $date_string = islandora_scholar_parse_date_foryear($online_date);
+      $date_string = islandora_google_scholar_parse_date_foryear($online_date);
       if ($date_string) {
         $tags['citation_online_date'] = $date_string;
       }
@@ -207,7 +214,7 @@ function islandora_scholar_create_meta_tags($object) {
  * @return null|string
  *   returns the year if the date was parsable and NULL otherwise
  */
-function islandora_scholar_parse_date_foryear($date) {
+function islandora_google_scholar_parse_date_foryear($date) {
   if (is_array($date)) {
     $date = (string) reset($date);
   }
@@ -234,7 +241,7 @@ function islandora_scholar_parse_date_foryear($date) {
  * @param array $tags
  *   An associate array containing the name => content of the meta tags.
  */
-function islandora_scholar_embed_tags($tags) {
+function islandora_google_scholar_embed_tags($tags) {
   $weight = 1000;
   if ($tags != FALSE) {
     foreach ($tags as $name => $content) {
@@ -266,4 +273,20 @@ function islandora_scholar_embed_tags($tags) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_CMODEL_islandora_view_object().
+ */
+function islandora_google_scholar_ir_citationCModel_islandora_view_object($object) {
+  $tags = islandora_google_scholar_create_meta_tags($object);
+  islandora_google_scholar_embed_tags($tags);
+}
+
+/**
+ * Implements hook_CMODEL_islandora_view_object().
+ */
+function islandora_google_scholar_ir_thesisCModel_islandora_view_object($object) {
+  $tags = islandora_google_scholar_create_meta_tags($object);
+  islandora_google_scholar_embed_tags($tags);
 }

--- a/includes/google_scholar.inc
+++ b/includes/google_scholar.inc
@@ -15,7 +15,7 @@
  *   Associative array where the key is the name of the tag and the value is
  *   the content.
  */
-function islandora_google_scholar_create_meta_tags($object) {
+function islandora_scholar_create_meta_tags($object) {
   // Need at least title, full name of at least one author, publication year.
   if (!isset($object['MODS']) || !islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS'])) {
     return FALSE;
@@ -113,7 +113,7 @@ function islandora_google_scholar_create_meta_tags($object) {
     // and we don't have a consistent structure of input we will just return the
     // year for now.
     if ($date) {
-      $date_string = islandora_google_scholar_parse_date_foryear($date);
+      $date_string = islandora_scholar_parse_date_foryear($date);
       if ($date_string) {
         $tags['citation_publication_date'] = $date_string;
       }
@@ -178,7 +178,7 @@ function islandora_google_scholar_create_meta_tags($object) {
 
     $online_date = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_online_date', '//mods:recordInfo/mods:recordCreationDate'));
     if ($online_date) {
-      $date_string = islandora_google_scholar_parse_date_foryear($online_date);
+      $date_string =  islandora_parse_date_foryear($online_date);
       if ($date_string) {
         $tags['citation_online_date'] = $date_string;
       }
@@ -214,7 +214,7 @@ function islandora_google_scholar_create_meta_tags($object) {
  * @return null|string
  *   returns the year if the date was parsable and NULL otherwise
  */
-function islandora_google_scholar_parse_date_foryear($date) {
+function islandora_scholar_parse_date_foryear($date) {
   if (is_array($date)) {
     $date = (string) reset($date);
   }
@@ -241,7 +241,7 @@ function islandora_google_scholar_parse_date_foryear($date) {
  * @param array $tags
  *   An associate array containing the name => content of the meta tags.
  */
-function islandora_google_scholar_embed_tags($tags) {
+function islandora_scholar_embed_tags($tags) {
   $weight = 1000;
   if ($tags != FALSE) {
     foreach ($tags as $name => $content) {
@@ -275,18 +275,3 @@ function islandora_google_scholar_embed_tags($tags) {
   }
 }
 
-/**
- * Implements hook_CMODEL_islandora_view_object().
- */
-function islandora_google_scholar_ir_citationCModel_islandora_view_object($object) {
-  $tags = islandora_google_scholar_create_meta_tags($object);
-  islandora_google_scholar_embed_tags($tags);
-}
-
-/**
- * Implements hook_CMODEL_islandora_view_object().
- */
-function islandora_google_scholar_ir_thesisCModel_islandora_view_object($object) {
-  $tags = islandora_google_scholar_create_meta_tags($object);
-  islandora_google_scholar_embed_tags($tags);
-}

--- a/includes/google_scholar.inc
+++ b/includes/google_scholar.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Module used to embed meta tags in the HEAD for use in indexing in Google
@@ -43,7 +44,7 @@ function islandora_scholar_create_meta_tags($object) {
     else {
       return FALSE;
     }
-    foreach ($mods_xml->xpath(variable_get('islandora_scholar_xpaths_authors_xpath', 'mods:name')) as $name_xml) {
+    foreach ($mods_xml->xpath(variable_get('islandora_scholar_xpaths_authors_xpath', '//mods:mods[1]/mods:name/mods:role[mods:roleTerm = "author"]/..')) as $name_xml) {
       $name_parts = array();
       $name_xml->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
       // Use Mods DisplayForm as a backup source for name.
@@ -178,7 +179,7 @@ function islandora_scholar_create_meta_tags($object) {
 
     $online_date = $mods_xml->xpath(variable_get('islandora_scholar_xpaths_online_date', '//mods:recordInfo/mods:recordCreationDate'));
     if ($online_date) {
-      $date_string =  islandora_parse_date_foryear($online_date);
+      $date_string = islandora_scholar_date_foryear($online_date);
       if ($date_string) {
         $tags['citation_online_date'] = $date_string;
       }
@@ -274,4 +275,3 @@ function islandora_scholar_embed_tags($tags) {
     }
   }
 }
-


### PR DESCRIPTION
### This is a replacement pull request for #323 




This is a pull request to make sure Google Scholar submodule will properly use the custom XPath settings in admin/islandora/solution_pack_config/scholar/xpaths for generating Google Scholar metatags, especially for authors.
In admin/islandora/solution_pack_config/scholar/xpaths, there are ways to set custom XPath for author information, including XPath for First Name, Last Name and one other fields just labeled as Authors. Currently in the file islandora_google_scholar.module, in line 43, it would just use “mods:name” as XPath and completely ignored what is set in the custom xpath settings. Furthermore, in line 50-54, it requires mods:role/mods:roleTerm and the roleTerm must be “author”. If roleTerms does not exist in MODS or the role is not author, it will not generate any information for authors. Since Google Scholar tags requires author information, it will not generate any Google Scholar tags if MODS does not match the hard-coded format exactly. Here is our sample MODS that current module will not be able to generate google scholar tags:
```xml
<name displayLabel="Creator(s)" type="personal">
    <namePart type="given">Brian</namePart>
    <namePart type="given">M*****</namePart>
    <namePart type="family">G****</namePart> 
    <displayForm>Brian M***** G*****</displayForm>
    <role>
        <roleTerm>Creator(s)</roleTerm>
    </role>
</name>
```
There are situations that “name” in MODS could be editors or advisors. However, since in the admin panel for custom xpath stated this is the xpaths for author, the custom xpaths should be accepted as author without roleTerm restriction. I also made accommodations in the code for middle name since it will have a namePart type given.

All the other required fields in the google scholar module works as intended and is taking custom xpath settings from the admin panel. I have tested my code in our islandora staging environment and it is generating google scholar meta tags in html header.
What's new?

    variable_get('islandora_scholar_xpaths_authors_xpath') to get custom authors xpath while keeping mods:name as default.
    Ignore roleTerm in MODS since the custom xpath settings specific says it is for authors.
    Take mods:displayForm as a backup source for name if namePart type does not match “family” nor “given”.
    It will accommodate more than one “given” name as middle name is marked as “given” in MODS.

How should this be tested?

    Find an object in Islandora that’s covered by Islandora Scholar module.
    In admin/islandora/solution_pack_config/scholar/xpaths, set custom xpaths for authors.
    Visit the object page and check HTML header to make sure meta name="citation_author" exists and is showing the correct information.
