### PR TITLE
Alters the code to delete accessCondition and physicalDescription at file upload

### DIFF
--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -223,8 +223,15 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   $xpath->registerNamespace('mods', $namespace);
 
   // Remove earlier instances of mods:accessCondition and mos:physicalDescription created by this form.
-  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"] | 
+  $permissions_config = explode("\n", variable_get('islandora_scholar_use_permissions', 'Publisher\nAuthor'));
+  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"] |
     //mods:accessCondition[@type="use and reproduction"][text()="publisher"]';
+  foreach ($permissions_config AS $permission) {
+    $access_condition_query = $access_condition_query . ' | //mods:accessCondition[@type="use and reproduction"][text()="' . $permission . '"]';
+  }
+/*
+  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"] | 
+    //mods:accessCondition[@type="use and reproduction"][text()="publisher"]'; */
   $physical_description_query = '//mods:physicalDescription[@authority="local"]';
   $results = $xpath->query("{$access_condition_query} | {$physical_description_query}");
   foreach ($results as $result) {

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -227,11 +227,9 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"] |
     //mods:accessCondition[@type="use and reproduction"][text()="publisher"]';
   foreach ($permissions_config AS $permission) {
+    $permission = str_replace( "\r", "", $permission);
     $access_condition_query = $access_condition_query . ' | //mods:accessCondition[@type="use and reproduction"][text()="' . $permission . '"]';
   }
-/*
-  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"] | 
-    //mods:accessCondition[@type="use and reproduction"][text()="publisher"]'; */
   $physical_description_query = '//mods:physicalDescription[@authority="local"]';
   $results = $xpath->query("{$access_condition_query} | {$physical_description_query}");
   foreach ($results as $result) {

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -221,14 +221,6 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   $doc->loadXML($object['MODS']->content);
   $xpath = new DOMXPath($doc);
   $xpath->registerNamespace('mods', $namespace);
-  // Remove all instances of mods:accessCondition and mods:physicalDescription
-  // from every mods:mods element instance.
-  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"]';
-  $physical_description_query = '//mods:physicalDescription[@authority="local"]';
-  $results = $xpath->query("{$access_condition_query} | {$physical_description_query}");
-  foreach ($results as $result) {
-    $result->parentNode->removeChild($result);
-  }
   // Regardless of the number of mods:mods elements in the document we only
   // add the usage and version to the first one.
   $results = $xpath->query('//mods:mods[1]');

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -221,6 +221,16 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   $doc->loadXML($object['MODS']->content);
   $xpath = new DOMXPath($doc);
   $xpath->registerNamespace('mods', $namespace);
+
+  // Remove earlier instances of mods:accessCondition and mos:physicalDescription created by this form.
+  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"]';
+  $physical_description_query = '//mods:physicalDescription[@authority="local"]';
+  $results = $xpath->query("{$access_condition_query} | {$physical_description_query}");
+  foreach ($results as $result) {
+    $result->parentNode->removeChild($result);
+  }
+
+
   // Regardless of the number of mods:mods elements in the document we only
   // add the usage and version to the first one.
   $results = $xpath->query('//mods:mods[1]');

--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -223,7 +223,8 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   $xpath->registerNamespace('mods', $namespace);
 
   // Remove earlier instances of mods:accessCondition and mos:physicalDescription created by this form.
-  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"]';
+  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"][text()="author"] | 
+    //mods:accessCondition[@type="use and reproduction"][text()="publisher"]';
   $physical_description_query = '//mods:physicalDescription[@authority="local"]';
   $results = $xpath->query("{$access_condition_query} | {$physical_description_query}");
   foreach ($results as $result) {


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/ISLANDORA-2515)

# What does this Pull Request do?

Tweaks the code to delete accessCondition and physicalDescription at file upload and makes it a bit more precise.

# What's new?

Previously, any metadata in the physicalDescription or accessCondition elements would be deliberately removed at the PDF Upload stage. I'm guessing the idea was to "make room" for the "document version" and "permission" selections, which are written to those fields, but there's no reason you can't have both. 

Now the existing elements remain, and the new elements are simply appended. They can coexist in harmony.

# How should this be tested?

1. Ingest an object as normal. Include some metadata in an accessCondition and/or physical Description element.
2. Include a PDF, select some options under the permission and version section.
3. Review metadata - your submitted accessCondition and physicalDescription are gone.
4. Check out this branch.
5. Ingest a new object (not "edit metadata"), do the same thing.
6. Review metadata - now both the submitted fields and the automatically-written fields should be present.

# Interested parties
@bryjbrown @DonRichards 
@Islandora/7-x-1-x-committers
