### PR TITLE
handle expiring/ed ds embargoes where the ds does not exist

### DIFF
--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -255,7 +255,14 @@ EOQ;
     }
 
     if (isset($params['dsid'])) {
-      rules_invoke_event('islandora_scholar_datastream_embargo_expiring', $item, $params['dsid']);
+      if (!isset($item[$params['dsid']])) {
+        $ds = $item->constructDatastream($params['dsid']);
+      }
+      else {
+        $ds = $item[$params['dsid']];
+      }
+
+      rules_invoke_event('islandora_scholar_datastream_embargo_expiring', $item, $ds);
     }
     else {
       rules_invoke_event('islandora_scholar_object_embargo_expiring', $item);
@@ -312,7 +319,13 @@ EOQ;
     // XXX: This needs to be removed as it is no longer shipped with the module
     // and is considered deprecated of 7.x-1.6.
     if (isset($params['dsid'])) {
-      rules_invoke_event('islandora_scholar_datastream_embargo_expired', $item, $params['dsid']);
+      if (!isset($item[$params['dsid']])) {
+        $ds = $item->constructDatastream($params['dsid']);
+      }
+      else {
+        $ds = $item[$params['dsid']];
+      }
+      rules_invoke_event('islandora_scholar_datastream_embargo_expired', $item, $ds);
     }
     else {
       rules_invoke_event('islandora_scholar_object_embargo_expired', $item);

--- a/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
+++ b/modules/islandora_scholar_embargo/islandora_scholar_embargo.module
@@ -254,8 +254,8 @@ EOQ;
       $expiry_emails[$params['pid']]['params']['dsid'] = array_merge($expiry_emails[$params['pid']]['params']['dsid'], $params['dsid']);
     }
 
-    if (isset($params['dsid']) && isset($item[$dsid])) {
-      rules_invoke_event('islandora_scholar_datastream_embargo_expiring', $item, $item[$dsid]);
+    if (isset($params['dsid'])) {
+      rules_invoke_event('islandora_scholar_datastream_embargo_expiring', $item, $params['dsid']);
     }
     else {
       rules_invoke_event('islandora_scholar_object_embargo_expiring', $item);
@@ -311,8 +311,8 @@ EOQ;
     }
     // XXX: This needs to be removed as it is no longer shipped with the module
     // and is considered deprecated of 7.x-1.6.
-    if (isset($params['dsid']) && isset($item[$dsid])) {
-      rules_invoke_event('islandora_scholar_datastream_embargo_expired', $item, $item[$dsid]);
+    if (isset($params['dsid'])) {
+      rules_invoke_event('islandora_scholar_datastream_embargo_expired', $item, $params['dsid']);
     }
     else {
       rules_invoke_event('islandora_scholar_object_embargo_expired', $item);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2528

# What does this Pull Request do?

The module allows embargos for datastreams that don't exist; lets take the same approach when lifting embargoes.

# What's new?
Don't require the object to have the referenced datastream in the embargo. If it doesn't exist, construct it and send it along.

# How should this be tested?
Set a scholar embargo for a datastream that doesn't exist.
Let it expire
Confirm cron has run
Confirm the RELS-INT and POLICY datastreams no longer reference the datastream that was embargoed.

# Interested parties
@Islandora/7-x-1-x-committers
